### PR TITLE
Updated robots and provided a limited sitemap of /latest/ content

### DIFF
--- a/doxygen-content-sitemap.xml
+++ b/doxygen-content-sitemap.xml
@@ -1,0 +1,2512 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/</loc>
+  <lastmod>2024-10-02T21:35:20+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/index.html</loc>
+  <lastmod>2024-10-02T21:35:20+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_getting_started.html</loc>
+  <lastmod>2024-10-02T21:28:40+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_u_g.html</loc>
+  <lastmod>2024-10-02T21:31:09+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.html</loc>
+  <lastmod>2024-10-02T21:31:05+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_cookbook.html</loc>
+  <lastmod>2024-10-02T21:28:29+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_t_n.html</loc>
+  <lastmod>2024-10-02T21:31:08+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_r_f_c.html</loc>
+  <lastmod>2024-10-02T21:31:04+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_s_p_e_c.html</loc>
+  <lastmod>2024-10-02T21:31:06+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_g_l_s.html</loc>
+  <lastmod>2024-10-02T21:28:39+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_about.html</loc>
+  <lastmod>2024-10-02T21:28:25+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/todo.html</loc>
+  <lastmod>2024-10-02T21:37:38+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_h_d_f5.html</loc>
+  <lastmod>2024-10-02T21:30:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_learn_h_d_f_view.html</loc>
+  <lastmod>2024-10-02T21:31:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_learn_basics.html</loc>
+  <lastmod>2024-10-02T21:30:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/md_doxygen_2examples_2menus_2high__level__menu.html</loc>
+  <lastmod>2024-10-02T21:35:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_par_h_d_f5.html</loc>
+  <lastmod>2024-10-02T21:30:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools.html</loc>
+  <lastmod>2024-10-02T21:31:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools_command.html</loc>
+  <lastmod>2024-10-02T21:31:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools_j_p_s_s.html</loc>
+  <lastmod>2024-10-02T21:31:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_v_d_s.html</loc>
+  <lastmod>2024-10-02T21:31:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_s_w_m_r.html</loc>
+  <lastmod>2024-10-02T21:31:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f5_examples.html</loc>
+  <lastmod>2024-10-02T21:28:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_m__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5__u_g.html</loc>
+  <lastmod>2024-10-02T21:28:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_g__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_s__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_a__u_g.html</loc>
+  <lastmod>2024-10-02T21:28:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_e__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_p__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_l__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_e_s__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_m__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_command_tools.html</loc>
+  <lastmod>2024-10-02T21:28:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_a_r__u_g.html</loc>
+  <lastmod>2024-10-02T21:28:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_a.html</loc>
+  <lastmod>2024-10-02T21:34:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_attribute.html</loc>
+  <lastmod>2024-10-02T21:31:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_a.html</loc>
+  <lastmod>2024-10-02T21:34:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_a.html</loc>
+  <lastmod>2024-10-02T21:34:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d.html</loc>
+  <lastmod>2024-10-02T21:34:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_set.html</loc>
+  <lastmod>2024-10-02T21:31:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_d.html</loc>
+  <lastmod>2024-10-02T21:34:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_d.html</loc>
+  <lastmod>2024-10-02T21:34:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html</loc>
+  <lastmod>2024-10-02T21:34:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_space.html</loc>
+  <lastmod>2024-10-02T21:31:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_s.html</loc>
+  <lastmod>2024-10-02T21:34:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_s.html</loc>
+  <lastmod>2024-10-02T21:34:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_t.html</loc>
+  <lastmod>2024-10-02T21:34:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_type.html</loc>
+  <lastmod>2024-10-02T21:31:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_t.html</loc>
+  <lastmod>2024-10-02T21:34:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_t.html</loc>
+  <lastmod>2024-10-02T21:34:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_e.html</loc>
+  <lastmod>2024-10-02T21:34:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_exception.html</loc>
+  <lastmod>2024-10-02T21:31:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_e.html</loc>
+  <lastmod>2024-10-02T21:34:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_e.html</loc>
+  <lastmod>2024-10-02T21:34:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_e_s.html</loc>
+  <lastmod>2024-10-02T21:34:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html</loc>
+  <lastmod>2024-10-02T21:34:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_h5_file.html</loc>
+  <lastmod>2024-10-02T21:31:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html</loc>
+  <lastmod>2024-10-02T21:34:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_f.html</loc>
+  <lastmod>2024-10-02T21:34:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_z.html</loc>
+  <lastmod>2024-10-02T21:34:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_z.html</loc>
+  <lastmod>2024-10-02T21:34:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_z.html</loc>
+  <lastmod>2024-10-02T21:34:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_g.html</loc>
+  <lastmod>2024-10-02T21:34:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_group.html</loc>
+  <lastmod>2024-10-02T21:31:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_g.html</loc>
+  <lastmod>2024-10-02T21:34:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_g.html</loc>
+  <lastmod>2024-10-02T21:34:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_i.html</loc>
+  <lastmod>2024-10-02T21:34:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_id_component.html</loc>
+  <lastmod>2024-10-02T21:31:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_i.html</loc>
+  <lastmod>2024-10-02T21:34:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_i.html</loc>
+  <lastmod>2024-10-02T21:34:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5.html</loc>
+  <lastmod>2024-10-02T21:34:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_h5_library.html</loc>
+  <lastmod>2024-10-02T21:31:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5.html</loc>
+  <lastmod>2024-10-02T21:34:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5.html</loc>
+  <lastmod>2024-10-02T21:34:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l.html</loc>
+  <lastmod>2024-10-02T21:34:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_l.html</loc>
+  <lastmod>2024-10-02T21:34:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_l.html</loc>
+  <lastmod>2024-10-02T21:34:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html</loc>
+  <lastmod>2024-10-02T21:34:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html</loc>
+  <lastmod>2024-10-02T21:34:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_o.html</loc>
+  <lastmod>2024-10-02T21:34:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_p.html</loc>
+  <lastmod>2024-10-02T21:34:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_p.html</loc>
+  <lastmod>2024-10-02T21:34:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_p.html</loc>
+  <lastmod>2024-10-02T21:34:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html</loc>
+  <lastmod>2024-10-02T21:34:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_r.html</loc>
+  <lastmod>2024-10-02T21:34:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_r.html</loc>
+  <lastmod>2024-10-02T21:34:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html</loc>
+  <lastmod>2024-10-02T21:34:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_v_l.html</loc>
+  <lastmod>2024-10-02T21:34:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_v_l.html</loc>
+  <lastmod>2024-10-02T21:34:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l_t.html</loc>
+  <lastmod>2024-10-02T21:34:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_l_t.html</loc>
+  <lastmod>2024-10-02T21:34:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_i_m.html</loc>
+  <lastmod>2024-10-02T21:34:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_i_m.html</loc>
+  <lastmod>2024-10-02T21:34:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_t_b.html</loc>
+  <lastmod>2024-10-02T21:34:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_t_b.html</loc>
+  <lastmod>2024-10-02T21:34:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_p_t.html</loc>
+  <lastmod>2024-10-02T21:34:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d_s.html</loc>
+  <lastmod>2024-10-02T21:34:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_d_s.html</loc>
+  <lastmod>2024-10-02T21:34:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d_o.html</loc>
+  <lastmod>2024-10-02T21:34:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l_r.html</loc>
+  <lastmod>2024-10-02T21:34:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f5_c_o_n_s_t.html</loc>
+  <lastmod>2024-10-02T21:28:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f_n_a_t_i_v_e.html</loc>
+  <lastmod>2024-10-02T21:28:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f_a_r_r_a_y.html</loc>
+  <lastmod>2024-10-02T21:28:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_e_r_r_o_r_s.html</loc>
+  <lastmod>2024-10-02T21:28:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/predefined_datatypes_tables.html</loc>
+  <lastmod>2024-10-02T21:36:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/deprecated.html</loc>
+  <lastmod>2024-10-02T21:32:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___a_s_y_n_c.html</loc>
+  <lastmod>2024-10-02T21:33:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html</loc>
+  <lastmod>2024-10-02T21:31:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___l_a_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___d_x_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___c_o_n_v.html</loc>
+  <lastmod>2024-10-02T21:34:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_r_m_t.html</loc>
+  <lastmod>2024-10-02T21:31:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_files.html</loc>
+  <lastmod>2024-10-02T21:28:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_attributes.html</loc>
+  <lastmod>2024-10-02T21:28:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_accessibility.html</loc>
+  <lastmod>2024-10-02T21:28:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_performance.html</loc>
+  <lastmod>2024-10-02T21:31:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_a_p_p_d_b_g.html</loc>
+  <lastmod>2024-10-02T21:28:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t_d_i_s_c.html</loc>
+  <lastmod>2024-10-02T21:28:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_i_l_e_i_m_g_o_p_s.html</loc>
+  <lastmod>2024-10-02T21:28:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_i_o_f_l_o_w.html</loc>
+  <lastmod>2024-10-02T21:30:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_t_n_m_d_c.html</loc>
+  <lastmod>2024-10-02T21:31:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/thread-safe-lib.html</loc>
+  <lastmod>2024-10-02T21:37:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_r_e_l_v_e_r_s_i_o_n.html</loc>
+  <lastmod>2024-10-02T21:31:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_v_f_l.html</loc>
+  <lastmod>2024-10-02T21:31:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_v_o_l__connector.html</loc>
+  <lastmod>2024-10-02T21:31:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_d_d_l_b_n_f110.html</loc>
+  <lastmod>2024-10-02T21:28:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_d_d_l_b_n_f112.html</loc>
+  <lastmod>2024-10-02T21:28:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_d_d_l_b_n_f114.html</loc>
+  <lastmod>2024-10-02T21:28:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t1.html</loc>
+  <lastmod>2024-10-02T21:28:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t11.html</loc>
+  <lastmod>2024-10-02T21:28:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t2.html</loc>
+  <lastmod>2024-10-02T21:28:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_f_m_t3.html</loc>
+  <lastmod>2024-10-02T21:28:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_i_m_g.html</loc>
+  <lastmod>2024-10-02T21:30:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_t_b_l.html</loc>
+  <lastmod>2024-10-02T21:31:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_ipublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_l_c_r.html</loc>
+  <lastmod>2024-10-02T21:34:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_ppublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_fpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_z__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_s__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_i_m__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_l_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_o__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_p_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_b__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_i__u_g.html</loc>
+  <lastmod>2024-10-02T21:29:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_l__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_o__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_i_e_e_e.html</loc>
+  <lastmod>2024-10-02T21:34:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_n_a_t.html</loc>
+  <lastmod>2024-10-02T21:34:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f5_l_i_b.html</loc>
+  <lastmod>2024-10-02T21:28:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5version_8h.html</loc>
+  <lastmod>2024-10-02T21:30:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5public_8h.html</loc>
+  <lastmod>2024-10-02T21:30:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1_h5.html</loc>
+  <lastmod>2024-10-02T21:32:21+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1_h_d_f5_constants.html</loc>
+  <lastmod>2024-10-02T21:32:21+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_s_t_d.html</loc>
+  <lastmod>2024-10-02T21:34:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_spublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_options.html</loc>
+  <lastmod>2024-10-02T21:37:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_com_dset.html</loc>
+  <lastmod>2024-10-02T21:30:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_examples.html</loc>
+  <lastmod>2024-10-02T21:30:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_file_org.html</loc>
+  <lastmod>2024-10-02T21:30:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_a_p_i.html</loc>
+  <lastmod>2024-10-02T21:30:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_prog.html</loc>
+  <lastmod>2024-10-02T21:30:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_file_create.html</loc>
+  <lastmod>2024-10-02T21:30:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_dset_create.html</loc>
+  <lastmod>2024-10-02T21:30:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_dset_r_w.html</loc>
+  <lastmod>2024-10-02T21:30:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_attr_create.html</loc>
+  <lastmod>2024-10-02T21:30:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_grp_create.html</loc>
+  <lastmod>2024-10-02T21:30:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_grp_create_names.html</loc>
+  <lastmod>2024-10-02T21:30:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_grp_dset.html</loc>
+  <lastmod>2024-10-02T21:30:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_dset_sub_r_w.html</loc>
+  <lastmod>2024-10-02T21:30:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_datatypes.html</loc>
+  <lastmod>2024-10-02T21:30:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_props_list.html</loc>
+  <lastmod>2024-10-02T21:30:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_dset_layout.html</loc>
+  <lastmod>2024-10-02T21:30:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_ext_dset.html</loc>
+  <lastmod>2024-10-02T21:30:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_contents.html</loc>
+  <lastmod>2024-10-02T21:30:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_quiz.html</loc>
+  <lastmod>2024-10-02T21:30:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_quiz_answers.html</loc>
+  <lastmod>2024-10-02T21:30:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_compiling.html</loc>
+  <lastmod>2024-10-02T21:30:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_l_b_training.html</loc>
+  <lastmod>2024-10-02T21:30:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/collective_calls.html</loc>
+  <lastmod>2024-10-02T21:32:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dmpi_8h.html</loc>
+  <lastmod>2024-10-02T21:29:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_par_cont_hyperslab.html</loc>
+  <lastmod>2024-10-02T21:30:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_par_regular_spaced.html</loc>
+  <lastmod>2024-10-02T21:30:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_par_pattern.html</loc>
+  <lastmod>2024-10-02T21:30:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_intro_par_chunk.html</loc>
+  <lastmod>2024-10-02T21:30:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_ex_a_p_i.html</loc>
+  <lastmod>2024-10-02T21:28:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools_view.html</loc>
+  <lastmod>2024-10-02T21:31:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools_edit.html</loc>
+  <lastmod>2024-10-02T21:31:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_view_tools_convert.html</loc>
+  <lastmod>2024-10-02T21:31:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_tpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:37+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_s.html</loc>
+  <lastmod>2024-10-02T21:34:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_dpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/h5repack_8h.html</loc>
+  <lastmod>2024-10-02T21:35:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/h5import_8h.html</loc>
+  <lastmod>2024-10-02T21:34:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___s_w_m_r.html</loc>
+  <lastmod>2024-10-02T21:34:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___a_t_o_m.html</loc>
+  <lastmod>2024-10-02T21:33:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___c_o_m_p_o_u_n_d.html</loc>
+  <lastmod>2024-10-02T21:34:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___o_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dsec2_8h.html</loc>
+  <lastmod>2024-10-02T21:29:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___m_d_c.html</loc>
+  <lastmod>2024-10-02T21:34:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_h5_f.html</loc>
+  <lastmod>2024-10-02T21:34:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dcore_8h.html</loc>
+  <lastmod>2024-10-02T21:29:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dlog_8h.html</loc>
+  <lastmod>2024-10-02T21:29:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dfamily_8h.html</loc>
+  <lastmod>2024-10-02T21:29:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dmulti_8h.html</loc>
+  <lastmod>2024-10-02T21:29:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dstdio_8h.html</loc>
+  <lastmod>2024-10-02T21:29:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dsplitter_8h.html</loc>
+  <lastmod>2024-10-02T21:29:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dmpio_8h.html</loc>
+  <lastmod>2024-10-02T21:29:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_ddirect_8h.html</loc>
+  <lastmod>2024-10-02T21:29:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dmirror_8h.html</loc>
+  <lastmod>2024-10-02T21:29:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dhdfs_8h.html</loc>
+  <lastmod>2024-10-02T21:29:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dros3_8h.html</loc>
+  <lastmod>2024-10-02T21:29:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dsubfiling_8h.html</loc>
+  <lastmod>2024-10-02T21:29:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dioc_8h.html</loc>
+  <lastmod>2024-10-02T21:29:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_donion_8h.html</loc>
+  <lastmod>2024-10-02T21:29:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dwindows_8h.html</loc>
+  <lastmod>2024-10-02T21:29:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_dpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___a_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:33:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___g_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:15+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___t_r_a_v.html</loc>
+  <lastmod>2024-10-02T21:34:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_rpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___d_a_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_p_l__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___l_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___s_c_a_l_e_o_f_f_s_e_t.html</loc>
+  <lastmod>2024-10-02T21:34:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t.html</loc>
+  <lastmod>2024-10-02T21:34:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_x86.html</loc>
+  <lastmod>2024-10-02T21:34:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___o_p_a_q_u_e.html</loc>
+  <lastmod>2024-10-02T21:34:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___c_o_m_p_e_n_u_m.html</loc>
+  <lastmod>2024-10-02T21:34:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___a_r_r_a_y.html</loc>
+  <lastmod>2024-10-02T21:33:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___e_n_u_m.html</loc>
+  <lastmod>2024-10-02T21:34:02+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___v_l_e_n.html</loc>
+  <lastmod>2024-10-02T21:34:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structhvl__t.html</loc>
+  <lastmod>2024-10-02T21:37:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_m_mpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_r__ref__t.html</loc>
+  <lastmod>2024-10-02T21:36:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_l_tpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structhdset__reg__ref__t.html</loc>
+  <lastmod>2024-10-02T21:37:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_apublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_epublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_e__error2__t.html</loc>
+  <lastmod>2024-10-02T21:36:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespacehdf5.html</loc>
+  <lastmod>2024-10-02T21:36:05+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___o_c_p_y_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___s_t_r_c_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_m_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l_d_e_v.html</loc>
+  <lastmod>2024-10-02T21:34:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l_d_e_f.html</loc>
+  <lastmod>2024-10-02T21:34:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_lconnector__passthru_8h.html</loc>
+  <lastmod>2024-10-02T21:30:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__token__t.html</loc>
+  <lastmod>2024-10-02T21:36:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l_n_a_t.html</loc>
+  <lastmod>2024-10-02T21:34:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__info2__t.html</loc>
+  <lastmod>2024-10-02T21:36:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_opublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:12+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__native__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__hdr__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5__ih__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_l__info2__t.html</loc>
+  <lastmod>2024-10-02T21:36:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_lpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:06+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_lpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_lnative_8h.html</loc>
+  <lastmod>2024-10-02T21:30:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__info1__t.html</loc>
+  <lastmod>2024-10-02T21:36:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespace_h5.html</loc>
+  <lastmod>2024-10-02T21:35:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l_a.html</loc>
+  <lastmod>2024-10-02T21:34:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_m.html</loc>
+  <lastmod>2024-10-02T21:34:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__c_p__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__d_f__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__d_p__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__f_c__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__i_m__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__j_a_m__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__l_s__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__r_p__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__s_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__c_r__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__d_g__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__d_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__m_g__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__r_t__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_t_o_o_l__w_h__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_a__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_abstract_ds.html</loc>
+  <lastmod>2024-10-02T21:31:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_h5_location.html</loc>
+  <lastmod>2024-10-02T21:31:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_exception_8h.html</loc>
+  <lastmod>2024-10-02T21:29:36+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_array_type.html</loc>
+  <lastmod>2024-10-02T21:31:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_comp_type.html</loc>
+  <lastmod>2024-10-02T21:31:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_enum_type.html</loc>
+  <lastmod>2024-10-02T21:31:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_int_type.html</loc>
+  <lastmod>2024-10-02T21:31:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_float_type.html</loc>
+  <lastmod>2024-10-02T21:31:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_str_type.html</loc>
+  <lastmod>2024-10-02T21:32:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_var_len_type.html</loc>
+  <lastmod>2024-10-02T21:32:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_link_acc_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_gpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_link_creat_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_d_set_creat_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_d_set_acc_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_g__stat__t.html</loc>
+  <lastmod>2024-10-02T21:36:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_attribute_8h.html</loc>
+  <lastmod>2024-10-02T21:29:04+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5a.html</loc>
+  <lastmod>2024-10-02T21:35:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1exceptions_1_1_h_d_f5_library_exception.html</loc>
+  <lastmod>2024-10-02T21:32:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_a__info__t.html</loc>
+  <lastmod>2024-10-02T21:32:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1exceptions_1_1_h_d_f5_exception.html</loc>
+  <lastmod>2024-10-02T21:32:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_a__iterate__cb.html</loc>
+  <lastmod>2024-10-02T21:35:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_a__iterate__t.html</loc>
+  <lastmod>2024-10-02T21:35:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_h5_object.html</loc>
+  <lastmod>2024-10-02T21:31:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_d_set_mem_xfer_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_data_set_8h.html</loc>
+  <lastmod>2024-10-02T21:29:12+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5d.html</loc>
+  <lastmod>2024-10-02T21:35:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_d__iterate__cb.html</loc>
+  <lastmod>2024-10-02T21:35:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_d__iterate__t.html</loc>
+  <lastmod>2024-10-02T21:35:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_data_space_8h.html</loc>
+  <lastmod>2024-10-02T21:29:12+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5s.html</loc>
+  <lastmod>2024-10-02T21:36:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_atom_type.html</loc>
+  <lastmod>2024-10-02T21:31:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_pred_type.html</loc>
+  <lastmod>2024-10-02T21:31:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_tdevelop_8h.html</loc>
+  <lastmod>2024-10-02T21:30:36+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_t__cdata__t.html</loc>
+  <lastmod>2024-10-02T21:36:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_data_type_8h.html</loc>
+  <lastmod>2024-10-02T21:29:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5t.html</loc>
+  <lastmod>2024-10-02T21:36:02+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_e__error1__t.html</loc>
+  <lastmod>2024-10-02T21:36:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_attribute_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_set_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_space_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_data_type_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:37+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_file_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_group_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_id_component_exception.html</loc>
+  <lastmod>2024-10-02T21:31:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_library_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_location_exception.html</loc>
+  <lastmod>2024-10-02T21:31:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_obj_header_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_prop_list_i_exception.html</loc>
+  <lastmod>2024-10-02T21:31:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_reference_exception.html</loc>
+  <lastmod>2024-10-02T21:31:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5e.html</loc>
+  <lastmod>2024-10-02T21:35:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5e_1_1h5eprint__f.html</loc>
+  <lastmod>2024-10-02T21:35:21+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_e__walk__cb.html</loc>
+  <lastmod>2024-10-02T21:35:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_e__walk__t.html</loc>
+  <lastmod>2024-10-02T21:35:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_e_s__err__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_e_spublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:18+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f__info2__t.html</loc>
+  <lastmod>2024-10-02T21:36:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f__sect__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f__info1__t.html</loc>
+  <lastmod>2024-10-02T21:36:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_common_f_g.html</loc>
+  <lastmod>2024-10-02T21:31:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_file_creat_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_file_acc_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_file_8h.html</loc>
+  <lastmod>2024-10-02T21:29:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5f.html</loc>
+  <lastmod>2024-10-02T21:35:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5f_1_1h5f__info__t.html</loc>
+  <lastmod>2024-10-02T21:37:17+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_f__info2__t.html</loc>
+  <lastmod>2024-10-02T21:32:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_zpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_zdevelop_8h.html</loc>
+  <lastmod>2024-10-02T21:30:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_z_p_r_e.html</loc>
+  <lastmod>2024-10-02T21:34:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_z__class1__t.html</loc>
+  <lastmod>2024-10-02T21:37:12+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_z__class2__t.html</loc>
+  <lastmod>2024-10-02T21:37:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5z.html</loc>
+  <lastmod>2024-10-02T21:36:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_g__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_o__stat__t.html</loc>
+  <lastmod>2024-10-02T21:36:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_group_8h.html</loc>
+  <lastmod>2024-10-02T21:29:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5g.html</loc>
+  <lastmod>2024-10-02T21:35:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5g_1_1h5g__info__t.html</loc>
+  <lastmod>2024-10-02T21:37:18+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_g__info__t.html</loc>
+  <lastmod>2024-10-02T21:32:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_o__token__t.html</loc>
+  <lastmod>2024-10-02T21:32:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_i_u_d.html</loc>
+  <lastmod>2024-10-02T21:34:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_idevelop_8h.html</loc>
+  <lastmod>2024-10-02T21:29:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/class_h5_1_1_obj_creat_prop_list.html</loc>
+  <lastmod>2024-10-02T21:31:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_id_component_8h.html</loc>
+  <lastmod>2024-10-02T21:29:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5i.html</loc>
+  <lastmod>2024-10-02T21:35:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_library_8h.html</loc>
+  <lastmod>2024-10-02T21:30:05+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5lib.html</loc>
+  <lastmod>2024-10-02T21:35:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_l__info1__t.html</loc>
+  <lastmod>2024-10-02T21:36:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/h5dump_8h.html</loc>
+  <lastmod>2024-10-02T21:34:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5l.html</loc>
+  <lastmod>2024-10-02T21:35:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5global_1_1h5o__token__t__f.html</loc>
+  <lastmod>2024-10-02T21:37:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_l__info__t.html</loc>
+  <lastmod>2024-10-02T21:32:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_l__iterate__t.html</loc>
+  <lastmod>2024-10-02T21:35:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_l__iterate__opdata__t.html</loc>
+  <lastmod>2024-10-02T21:35:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5o.html</loc>
+  <lastmod>2024-10-02T21:36:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5global.html</loc>
+  <lastmod>2024-10-02T21:35:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5o_1_1h5o__info__t.html</loc>
+  <lastmod>2024-10-02T21:37:21+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_o__info__t.html</loc>
+  <lastmod>2024-10-02T21:32:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_o__iterate__t.html</loc>
+  <lastmod>2024-10-02T21:35:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_o__iterate__opdata__t.html</loc>
+  <lastmod>2024-10-02T21:35:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_o__native__info__t.html</loc>
+  <lastmod>2024-10-02T21:32:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_l_c_r_a.html</loc>
+  <lastmod>2024-10-02T21:34:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___g_a_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_prop_list_8h.html</loc>
+  <lastmod>2024-10-02T21:30:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5p.html</loc>
+  <lastmod>2024-10-02T21:36:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5p_1_1h5fd__subfiling__params__t.html</loc>
+  <lastmod>2024-10-02T21:37:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__subfiling__params__t.html</loc>
+  <lastmod>2024-10-02T21:36:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5p_1_1h5fd__subfiling__config__t.html</loc>
+  <lastmod>2024-10-02T21:37:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__subfiling__config__t.html</loc>
+  <lastmod>2024-10-02T21:36:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5p_1_1h5fd__ioc__config__t.html</loc>
+  <lastmod>2024-10-02T21:37:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__ioc__config__t.html</loc>
+  <lastmod>2024-10-02T21:36:33+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5p_1_1h5pget__fapl__mpio__f.html</loc>
+  <lastmod>2024-10-02T21:35:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5p_1_1h5pget__mpi__params__f.html</loc>
+  <lastmod>2024-10-02T21:35:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5p_1_1h5pset__fapl__mpio__f.html</loc>
+  <lastmod>2024-10-02T21:35:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5p_1_1h5pset__mpi__params__f.html</loc>
+  <lastmod>2024-10-02T21:35:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_p__iterate__cb.html</loc>
+  <lastmod>2024-10-02T21:35:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfacehdf_1_1hdf5lib_1_1callbacks_1_1_h5_p__iterate__t.html</loc>
+  <lastmod>2024-10-02T21:35:36+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_a_c__cache__config__t.html</loc>
+  <lastmod>2024-10-02T21:32:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_f_d__hdfs__fapl__t.html</loc>
+  <lastmod>2024-10-02T21:32:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1structs_1_1_h5_f_d__ros3__fapl__t.html</loc>
+  <lastmod>2024-10-02T21:32:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_a_c__cache__config__t.html</loc>
+  <lastmod>2024-10-02T21:36:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_p_lpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:30:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5global_1_1hobj__ref__t__f.html</loc>
+  <lastmod>2024-10-02T21:37:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5r.html</loc>
+  <lastmod>2024-10-02T21:36:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structh5global_1_1hdset__reg__ref__t__f.html</loc>
+  <lastmod>2024-10-02T21:37:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5r_1_1h5rget__object__type__f.html</loc>
+  <lastmod>2024-10-02T21:35:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_r__u_g.html</loc>
+  <lastmod>2024-10-02T21:30:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l_p_t.html</loc>
+  <lastmod>2024-10-02T21:34:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5vl.html</loc>
+  <lastmod>2024-10-02T21:36:02+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5lt.html</loc>
+  <lastmod>2024-10-02T21:36:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5im.html</loc>
+  <lastmod>2024-10-02T21:35:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5tb.html</loc>
+  <lastmod>2024-10-02T21:36:02+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5tb_1_1h5tbinsert__field__f.html</loc>
+  <lastmod>2024-10-02T21:35:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5tb_1_1h5tbread__field__index__f.html</loc>
+  <lastmod>2024-10-02T21:35:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5tb_1_1h5tbread__field__name__f.html</loc>
+  <lastmod>2024-10-02T21:35:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5tb_1_1h5tbwrite__field__index__f.html</loc>
+  <lastmod>2024-10-02T21:35:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/interfaceh5tb_1_1h5tbwrite__field__name__f.html</loc>
+  <lastmod>2024-10-02T21:35:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespaceh5ds.html</loc>
+  <lastmod>2024-10-02T21:35:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_d_spublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_input.html</loc>
+  <lastmod>2024-10-02T21:37:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1exceptions_1_1_h_d_f5_java_exception.html</loc>
+  <lastmod>2024-10-02T21:32:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_u_n_i_x.html</loc>
+  <lastmod>2024-10-02T21:34:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_a_l_p_h_a.html</loc>
+  <lastmod>2024-10-02T21:34:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_m_i_p_s.html</loc>
+  <lastmod>2024-10-02T21:34:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___p_d_t_c9x.html</loc>
+  <lastmod>2024-10-02T21:34:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___t_a_p_l.html</loc>
+  <lastmod>2024-10-02T21:34:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/group___f_l_e_t_c_h_e_r32.html</loc>
+  <lastmod>2024-10-02T21:34:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_f_ddevelop_8h.html</loc>
+  <lastmod>2024-10-02T21:29:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_a_cpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_cpublic_8h.html</loc>
+  <lastmod>2024-10-02T21:29:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_lconnector_8h.html</loc>
+  <lastmod>2024-10-02T21:30:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_p_lextern_8h.html</loc>
+  <lastmod>2024-10-02T21:30:19+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__optional__args__t.html</loc>
+  <lastmod>2024-10-02T21:37:10+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__info__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__wrap__class__t.html</loc>
+  <lastmod>2024-10-02T21:37:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__dataset__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__datatype__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__group__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__link__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__object__class__t.html</loc>
+  <lastmod>2024-10-02T21:37:08+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__introspect__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__request__class__t.html</loc>
+  <lastmod>2024-10-02T21:37:10+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__blob__class__t.html</loc>
+  <lastmod>2024-10-02T21:36:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__token__class__t.html</loc>
+  <lastmod>2024-10-02T21:37:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__loc__params__t.html</loc>
+  <lastmod>2024-10-02T21:37:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__loc__by__token__t.html</loc>
+  <lastmod>2024-10-02T21:37:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__loc__by__name__t.html</loc>
+  <lastmod>2024-10-02T21:37:00+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__loc__by__idx__t.html</loc>
+  <lastmod>2024-10-02T21:36:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__get__name__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__get__info__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__iterate__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__attr__delete__by__idx__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__dataset__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__dataset__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__datatype__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__datatype__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__object__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:37:09+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__cont__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:53+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__get__name__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__file__get__obj__ids__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__group__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__group__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__group__get__info__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__group__spec__mount__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__link__create__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__link__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__link__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__link__iterate__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:58+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__object__get__args__t.html</loc>
+  <lastmod>2024-10-02T21:37:09+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__object__visit__args__t.html</loc>
+  <lastmod>2024-10-02T21:37:10+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__request__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:37:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_v_l__blob__specific__args__t.html</loc>
+  <lastmod>2024-10-02T21:36:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/dir_68267d1309a1af8e8297ef4c3efbcdba.html</loc>
+  <lastmod>2024-10-02T21:33:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__file__image__callbacks__t.html</loc>
+  <lastmod>2024-10-02T21:36:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_a_c__cache__image__config__t.html</loc>
+  <lastmod>2024-10-02T21:36:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f__retry__info__t.html</loc>
+  <lastmod>2024-10-02T21:36:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/classhdf_1_1hdf5lib_1_1_h_d_f_array.html</loc>
+  <lastmod>2024-10-02T21:32:20+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_e_r_r_o_r_s_l_i_b.html</loc>
+  <lastmod>2024-10-02T21:28:32+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_e_r_r_o_r_s_j_a_v_a.html</loc>
+  <lastmod>2024-10-02T21:28:32+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h5_8java.html</loc>
+  <lastmod>2024-10-02T21:28:58+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/namespacehdf_1_1hdf5lib.html</loc>
+  <lastmod>2024-10-02T21:36:04+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/_h_d_f5_constants_8java.html</loc>
+  <lastmod>2024-10-02T21:28:43+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/structinfilesformat.html</loc>
+  <lastmod>2024-10-02T21:37:27+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__hdfs__fapl__t.html</loc>
+  <lastmod>2024-10-02T21:36:33+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://support.hdfgroup.org/documentation/hdf5/latest/struct_h5_f_d__mirror__fapl__t.html</loc>
+  <lastmod>2024-10-02T21:36:33+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+
+
+</urlset>

--- a/robots.txt
+++ b/robots.txt
@@ -4,4 +4,10 @@ Disallow:
 Disallow: /cgi-bin/
 Disallow: /archive/
 Disallow: /releases/hdf5/v1_14/
+Disallow: /ftp/HDF/prev-Documentation/
+Disallow: /ftp/newsletters/
+Disallow: /ftp/HDF5/documentation/
+Disallow: /ftp/HDF5/examples/
+Disallow: /ftp/HDF5/projects/
 Sitemap: https://support.hdfgroup.org/sitemap.xml
+Sitemap: https://support.hdfgroup.org/doxygen-content-sitemap.xml


### PR DESCRIPTION
I edited robots.txt to remove some more directories that were outdated or duplicated. I added a sitemap generated from a free site that has 500 pages of /latest/ which will help with the canonical user error. This doesn't mark off getting a good sitemap as DONE, but this is a temporary step that will help people find the content in the right place and improve google results. 

Internal discussion: https://hdfgroup.atlassian.net/browse/IWIP-513 