### PR TITLE
Fix to use relative links

### DIFF
--- a/documentation/hdf5-docs/Migrating+from+HDF5+1.12+to+HDF5+1.14.md
+++ b/documentation/hdf5-docs/Migrating+from+HDF5+1.12+to+HDF5+1.14.md
@@ -7,7 +7,7 @@ redirect_from:
 # Migrating from HDF5 1.12 to HDF5 1.14
 
 ## API Changes
-There are new API calls that require API Compatibility Macros in HDF5 1.14.0. There are, however, two API calls which have had their signature change.
+There are new API calls that require [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 1.14.0. There are, however, two API calls which have had their signature change.
 
 ### `H5Iregister_type()` / `H5I_free_t`
 The signature of `H5Iregister_type()` did not change, but the `H5I_free_t` callback it accepts did have its signature change to add an asynchronous request parameter. There is no API compatibility macro to paper over this change. The request parameter can be ignored in the callback if you are not concerned with asynchronous operations and future IDs. A description of how the request parameter should be used will be found in the (soon to be released) HDF5 Asynchronous Programming Guide.

--- a/documentation/hdf5-docs/advanced_topics_list.md
+++ b/documentation/hdf5-docs/advanced_topics_list.md
@@ -9,19 +9,19 @@ redirect_from:
 
 | Topic                         | Description                                                  |
 | ----------------------------- | ------------------------------------------------------------ |
-| [Chunking in HDF5](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/chunking_in_hdf5.html) | Provides detailed information regarding chunking in HDF5 |
+| [Chunking in HDF5](/documentation/advanced_topics/chunking_in_hdf5.html) | Provides detailed information regarding chunking in HDF5 |
 | [HDF5 File Image Operations (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/HDF5FileImageOperations.pdf) | Describes how to work with HDF5 files in memory. Disk I/O is not required when file images are opened, created, read from, or written to |
-| [Copying Committed Datatypes with H5Ocopy (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/CopyingCommittedDatatypesWithH5Ocopy.pdf) | Describes how to copy to another file a dataset that uses a committed datatype or an object with an attribute that uses a committed datatype so that the committed datatype in the destination file can be used by multiple objects|
-| [Collective Metadata I/O](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/CollectiveMetadataIO.html) | Describes optimizing HDF5 by collecting metadata I/O |
+| [Copying Committed Datatypes with H5Ocopy (PDF)](/documentation/advanced_topics/CopyingCommittedDatatypesWithH5Ocopy.pdf) | Describes how to copy to another file a dataset that uses a committed datatype or an object with an attribute that uses a committed datatype so that the committed datatype in the destination file can be used by multiple objects|
+| [Collective Metadata I/O](/documentation/advanced_topics/CollectiveMetadataIO.html) | Describes optimizing HDF5 by collecting metadata I/O |
 | [Enabling a Strict Consistency Semantics Model in Parallel HDF5 (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC%20PHDF5%20Consistency%20Semantics%20MC%20120328.docx.pdf) | Describes how to improve file access consistency semantics with the Parallel HDF5 library |
-| [File Space Management](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/FileSpaceManagement.html) | Describes mechanisms to manage space in an HDF5 file |
-| [Fine-tuning the Metadata Cache](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/FineTuningMetadataCache.html) | Describes how to provide better control of the metadata cache |
+| [File Space Management](/documentation/advanced_topics/FileSpaceManagement.html) | Describes mechanisms to manage space in an HDF5 file |
+| [Fine-tuning the Metadata Cache](/documentation/advanced_topics/FineTuningMetadataCache.html) | Describes how to provide better control of the metadata cache |
 | [Freeing Memory Allocated by the HDF5 Library (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC%20H5free_memory%20v2.pdf) | Describes how inconsistent memory management can cause heap corruption or resource leaks and possible solutions |
-| [HDF5 Data Flow Pipeline for H5Dread](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/data_flow_pline_H5Dread.html) | Describes data flow when reading raw data from an HDF5 dataset |
-| [HDF5 Metadata](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/) | Provides a comprehensive overview of the types of metadata used in HDF5 |
-| [Introduction to Single-Writer_Multiple-Reader (SWMR)](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/intro_SWMR.html) | Enables writing to a file while multiple readers are accessing it |
-| [Introduction to the Virtual Dataset - VDS](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/intro_VDS.html) | Describes how to present data stored in several HDF5 datasets and files as a single dataset and access the data using HDF5 APIs |
-| [Modified Region Writes (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics/ModifiedRegionWrites.pdf) | Describes how to set write operations for in-memory files so that only modified regions are written to storage. Available when the Core (Memory) VFD is used |
+| [HDF5 Data Flow Pipeline for H5Dread](/documentation/advanced_topics/data_flow_pline_H5Dread.html) | Describes data flow when reading raw data from an HDF5 dataset |
+| [HDF5 Metadata](/documentation/advanced_topics/) | Provides a comprehensive overview of the types of metadata used in HDF5 |
+| [Introduction to Single-Writer_Multiple-Reader (SWMR)](/documentation/advanced_topics/intro_SWMR.html) | Enables writing to a file while multiple readers are accessing it |
+| [Introduction to the Virtual Dataset - VDS](/documentation/advanced_topics/intro_VDS.html) | Describes how to present data stored in several HDF5 datasets and files as a single dataset and access the data using HDF5 APIs |
+| [Modified Region Writes (PDF)](/documentation/advanced_topics/ModifiedRegionWrites.pdf) | Describes how to set write operations for in-memory files so that only modified regions are written to storage. Available when the Core (Memory) VFD is used |
 | [Page Buffering (PDF)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC-Page_Buffering.pdf) | Describes how to reduce the number of small accesses in HDF5 by buffering metadata and raw data accesses |
 | [Partial Edge Chunks]() | Describes how to control the filtering of partial edge chunks to improve performance when extending datasets |
 | [Thread-safe HDF5]() | Information on thread-safety and concurrent access in HDF5 |

--- a/documentation/hdf5-docs/hdf5_topics/CollectiveCallsInParallel.md
+++ b/documentation/hdf5-docs/hdf5_topics/CollectiveCallsInParallel.md
@@ -10,14 +10,14 @@ redirect_from:
 This document addresses two topics of concern in a parallel computing environment:
 * HDF5 functions that must be called collectively and when
 * Properties that must be used in a coordinated manner
-The term Macro in the “Additional notes” column indicates that the first item in the “Function” column of the same row is a macro that is selectively mapped to one of the two immediately-following functions. For example, H5Acreate is a macro that can be mapped to either H5Acreate1 or H5Acreate2. This mapping is configurable and is explained in [API Compatibility Macros in HDF5](API compatibility...). The macro structure was introduced at HDF5 Release 1.8.0.
+The term Macro in the “Additional notes” column indicates that the first item in the “Function” column of the same row is a macro that is selectively mapped to one of the two immediately-following functions. For example, H5Acreate is a macro that can be mapped to either H5Acreate1 or H5Acreate2. This mapping is configurable and is explained in [API Compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html). The macro structure was introduced at HDF5 Release 1.8.0.
 
 ## Always collective
 The following functions must always be called collectively.
 
 | API |   Function  | All processes:<br>same datatype<br>& dataspace | All processes:<br>same access<br>properties | All processes:<br>same creation<br>properties | Available<br>in releases since | Additional notes |
 | --- | ----------- | ---------------- | ---------------------------------------- | ------------------------------------------ | ------------------------------ | ----------- |
-| H5A | H5Acreate<br>H5Acreate1<br>H5Acreate2 | ✓ | ✓ | ✓ | 1.8.x | [Macro](API compatibility...)<br>The function H5Acreate was renamed to H5Acreate1 at Release 1.8.0. |
+| H5A | H5Acreate<br>H5Acreate1<br>H5Acreate2 | ✓ | ✓ | ✓ | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Acreate was renamed to H5Acreate1 at Release 1.8.0. |
 |     | H5Acreate_by_name                     | ✓ | ✓ | ✓ | 1.8.x | |
 |     | H5Adelete                             |   |   |   |       | |
 |     | H5Adelete_by_idx                      |   |   |   | 1.8.x | |
@@ -25,7 +25,7 @@ The following functions must always be called collectively.
 |     | H5Arename                             |   |   |   | 1.6.x | |
 |     | H5Arename_by_name                     |   |   |   | 1.8.x | |
 |     | H5Awrite                              |   |   |   |       | Because raw data for an attribute is cached locally, all processes must participate in order to guarantee that future H5Aread calls return correct results on all processes. |
-| H5D | H5Dcreate<br>H5Dcreate1<br>H5Dcreate2 | ✓ | ✓ | ✓ | 1.8.x | [Macro](API compatibility...)<br>The function H5Dcreate was renamed to H5Dcreate1 at Release 1.8.0. |
+| H5D | H5Dcreate<br>H5Dcreate1<br>H5Dcreate2 | ✓ | ✓ | ✓ | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Dcreate was renamed to H5Dcreate1 at Release 1.8.0. |
 |     | H5Dcreate_anon                        | ✓ | ✓ | ✓ | 1.8.x | |
 |     | H5Dextend                             |   |   |   |       | All processes must participate only if the number of chunks in the dataset actually changes.<br>All processes must use the same dataspace dimensions. |
 |     | H5Dset_extent                         |   |   |   | 1.6.x | All processes must participate only if the number of chunks in the dataset actually changes.<br>All processes must use the same dataspace dimensions. |
@@ -36,7 +36,7 @@ The following functions must always be called collectively.
 |     | H5Fopen                               |   | ✓ |   |       | |
 |     | H5Freopen                             |   |   |   |       | |
 |     | H5Funmount                            |   |   |   |       | |
-| H5G | H5Gcreate<br>H5Gcreate1<br>H5Gcreate2 |   | ✓ | ✓ | 1.8.x | [Macro](API compatibility...)<br>The function H5Gcreate was renamed to H5Gcreate1 at Release 1.8.0. |
+| H5G | H5Gcreate<br>H5Gcreate1<br>H5Gcreate2 |   | ✓ | ✓ | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Gcreate was renamed to H5Gcreate1 at Release 1.8.0. |
 |     | H5Gcreate_anon                        |   | ✓ | ✓ | 1.8.x | |
 |     | H5Glink                               |   |   |   |       | |
 |     | H5Glink2                              |   |   |   | 1.6.x | |
@@ -61,7 +61,7 @@ The following functions must always be called collectively.
 |     | H5Oset_comment                        |   |   |   | 1.8.x | |
 |     | H5Oset_comment_by_name                |   |   |   | 1.8.x | |
 | H5R | H5Rcreate                             |   |   |   |       | |
-| H5T | H5Tcommit<br>H5Tcommit1<br>H5Tcommit2 |   | ✓ | ✓ | 1.8.x | [Macro](API compatibility...)<br>The function H5Tcommit was renamed to H5Tcommit1 at Release 1.8.0. |
+| H5T | H5Tcommit<br>H5Tcommit1<br>H5Tcommit2 |   | ✓ | ✓ | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Tcommit was renamed to H5Tcommit1 at Release 1.8.0. |
 |     | H5Tcommit_anon                        |   | ✓ | ✓ | 1.8.x | |
 
 ## Collective, unless target object will not be modified
@@ -77,9 +77,9 @@ The following functions must normally be called collectively. If, however, the t
 |     | H5Aopen_idx     |   | ✓ |   |       | |
 |     | H5Aopen_name    |   | ✓ |   |       | |
 | H5D | H5Dclose        |   |   |   | 1.8.x | 	All processes must participate only if all file identifiers for a file have been closed and this is the last outstanding object identifier. |
-|     | H5Dopen<br>H5Dopen1<br>H5Dopen2 |   | ✓ |   | 1.8.x | [Macro](API compatibility...)<br>The function H5Dopen was renamed to H5Dopen1 at Release 1.8.0. |
+|     | H5Dopen<br>H5Dopen1<br>H5Dopen2 |   | ✓ |   | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Dopen was renamed to H5Dopen1 at Release 1.8.0. |
 | H5G | H5Gclose        |   |   |   |       | All processes must participate only if all file identifiers for a file have been closed and this is the last outstanding object identifier. |
-|     | H5Gopen<br>H5Gopen1<br>H5Gopen2 |   | ✓ |   | 1.8.x | [Macro](API compatibility...)<br>The function H5Gopen was renamed to H5Dopen1 at Release 1.8.0. |
+|     | H5Gopen<br>H5Gopen1<br>H5Gopen2 |   | ✓ |   | 1.8.x | [Macro](/documentation/hdf5/latest/api-compat-macros.html)<br>The function H5Gopen was renamed to H5Dopen1 at Release 1.8.0. |
 | H5I | H5Iget_file_id  |   |   |   | 1.8.x | |
 | H5O | H5Oclose        |   |   |   | 1.8.x | All processes must participate only if all file identifiers for a file have been closed and this is the last outstanding object identifier. |
 |     | H5Oopen         |   | ✓ |   | 1.8.x | |
@@ -89,7 +89,7 @@ The following functions must normally be called collectively. If, however, the t
 | H5T | H5Tclose        |   |   |   |       | All processes must participate only if the datatype is for a committed datatype, all the file identifiers for the file have been closed, and this is the last outstanding object identifier. |
      H5Topen
 H5Topen1
-H5Topen2         ✓         1.8.x    [Macro](API compatibility...)
+H5Topen2         ✓         1.8.x    [Macro](/documentation/hdf5/latest/api-compat-macros.html)
 The function H5Topen was renamed to H5Topen1 at Release 1.8.0.
 
 ## Properties

--- a/documentation/hdf5-docs/hdf5_topics_list.md
+++ b/documentation/hdf5-docs/hdf5_topics_list.md
@@ -10,17 +10,17 @@ redirect_from:
 
 | Topic                         | Description                                                  |
 | ----------------------------- | ------------------------------------------------------------ |
-| [Environment Variables Used by HDF5](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/EnvVarsUsedByHDF5.html) | Environment variables that can be used when building or using HDF5 |
-| [Using Compression in HDF5](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/UsingCompressionInHDF5.html) | Resources regarding compression |
-| [Improving I/O Performance When Working with HDF5 Compressed Datasets](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/HDF5ImprovingIOPerformanceCompressedDatasets.pdf) | A description of the factors that should be considered when storing compressed data in HDF5 files and how to tune those parameters to optimize the I/O performance of an HDF5 application when working with compressed datasets (PDF) |
-| [Parallel HDF5](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/ParallelHDF5.html) | Information on Parallel HDF5 |
+| [Environment Variables Used by HDF5](/documentation/hdf5_topics/EnvVarsUsedByHDF5.html) | Environment variables that can be used when building or using HDF5 |
+| [Using Compression in HDF5](/documentation/hdf5_topics/UsingCompressionInHDF5.html) | Resources regarding compression |
+| [Improving I/O Performance When Working with HDF5 Compressed Datasets](/documentation/hdf5_topics/HDF5ImprovingIOPerformanceCompressedDatasets.pdf) | A description of the factors that should be considered when storing compressed data in HDF5 files and how to tune those parameters to optimize the I/O performance of an HDF5 application when working with compressed datasets (PDF) |
+| [Parallel HDF5](/documentation/hdf5_topics/ParallelHDF5.html) | Information on Parallel HDF5 |
 | [Fill Value and Space Allocation Behavior]() | A table summarizing of the behavioral interactions of HDF5 fill value and storage allocation settings  |
 | [H5Fill Behavior]() | The library's fill value behavior for property list settings |
-| [Using Identifiers](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/UsingIdentifiers.html) | Description of how identifiers work |
-| [UTF-8 encoding in HDF5 applications](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/UsingUTF-8EncodinginHDF5Apps.html) | Information on using UTF-8 encoding in HDF5 applications |
-| [HDF5 Dimension Scale Specification and Design Notes](https://support.hdfgroup.org/releases/hdf5/documentation/hdf5_topics/H5DS_Spec.pdf) | |
+| [Using Identifiers](/documentation/hdf5_topics/UsingIdentifiers.html) | Description of how identifiers work |
+| [UTF-8 encoding in HDF5 applications](/documentation/hdf5_topics/UsingUTF-8EncodinginHDF5Apps.html) | Information on using UTF-8 encoding in HDF5 applications |
+| [HDF5 Dimension Scale Specification and Design Notes](/documentation/hdf5_topics/H5DS_Spec.pdf) | |
 
 <!--- In doxygen/technical notes -->
 <!--- | [HDF5 Library Release Versions Numbers]() | A description of HDF5 library release version numbering | -->
 
-For more advanced features, see [Advanced Topics in HDF5](https://support.hdfgroup.org/releases/hdf5/documentation/advanced_topics_list.html)
+For more advanced features, see [Advanced Topics in HDF5](/documentation/hdf5-docs/advanced_topics_list.html)

--- a/documentation/hdf5-docs/release_specific_info.md
+++ b/documentation/hdf5-docs/release_specific_info.md
@@ -6,24 +6,24 @@ redirect_from:
 
 # Release Specific Information
 
-### [HDF5 1.14](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/hdf5_1_14.html)
-* [New Features](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/new_features_1_14.html)
-* [Software Changes from Release to Release](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/sw_changes_1.14.html)
-* [Migrating to HDF5 1.14 from previous releases](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/Migrating_from_HDF5_1.12_to_HDF5_1.14.html)
+### [HDF5 1.14](/documentation/release_specifics/hdf5_1_14.html)
+* [New Features](/documentation/release_specifics/new_features_1_14.html)
+* [Software Changes from Release to Release](/documentation/release_specifics/sw_changes_1.14.html)
+* [Migrating to HDF5 1.14 from previous releases](/documentation/release_specifics/Migrating_from_HDF5_1.12_to_HDF5_1.14.html)
 
-### [HDF5 1.12](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/hdf5_1_12.html)
-* [New Features](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/new_features_1_12.html)
-* [Software Changes from Release to Release](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/sw_changes_1.12.html)
-* [Migrating from HDF5 1.10 to HDF5 1.12](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/Migrating_from_HDF5_1.10_to_HDF5_1.12.html)
+### [HDF5 1.12](/documentation/release_specifics/hdf5_1_12.html)
+* [New Features](/documentation/release_specifics/new_features_1_12.html)
+* [Software Changes from Release to Release](/documentation/release_specifics/sw_changes_1.12.html)
+* [Migrating from HDF5 1.10 to HDF5 1.12](/documentation/release_specifics/Migrating_from_HDF5_1.10_to_HDF5_1.12.html)
 
-### [HDF5 1.10](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/hdf5_1_10.html)
-* [New Features](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/new_features_1_10.html)
+### [HDF5 1.10](/documentation/release_specifics/hdf5_1_10.html)
+* [New Features](/documentation/release_specifics/new_features_1_10.html)
 * [Why should I care about the HDF5-1.10.2 release? (blog)]()
-* [Software Changes from Release to Release](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/sw_changes_1.10.html)
-* [Migrating from HDF5 1.8 to HDF5 1.10](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/Migrating_from_HDF5_1.8_to_HDF5_1.10.html)
+* [Software Changes from Release to Release](/documentation/release_specifics/sw_changes_1.10.html)
+* [Migrating from HDF5 1.8 to HDF5 1.10](/documentation/release_specifics/Migrating_from_HDF5_1.8_to_HDF5_1.10.html)
 
-### [HDF5 1.8](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/hdf5_1_8.html)
+### [HDF5 1.8](/documentation/release_specifics/hdf5_1_8.html)
 * New Features
-* [Software Changes from Release to Release](https://support.hdfgroup.org/releases/hdf5/documentation/release_specifics/sw_changes_1.8.html)
+* [Software Changes from Release to Release](/documentation/release_specifics/sw_changes_1.8.html)
 
-### [API Compatibility Macros in HDF5](https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html)
+### [API Compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html)

--- a/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.10_to_HDF5_1.12.md
+++ b/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.10_to_HDF5_1.12.md
@@ -10,14 +10,14 @@ Also see the video presentation: [Moving Applications from 1.10 to 1.12](https:/
 
 There were many existing functions that were modified in 1.12. Applications created with 1.10 or earlier that use these functions will encounter errors when compiled with 1.12. This page describes how to compile 1.10 and earlier applications with 1.12 without modifying an application, and provides details on the functions that changed for users who wish to update their applications.
 
-* [Compiling 1.10 and earlier applications with 1.12](#Compiling-1.10-and-earlier-applications-with-1.12)
-* [Functions that changed](#Functions-that-changed)
+* <a href="#compiling-1.10-and-earlier-applications-with-1.12">Compiling 1.10 and earlier applications with 1.12</a>
+* <a href="#funcsthatchanged">Functions that changed</a>
 
 For further information, see:
 
-* [New Features in 1.12](new_features_1_12.md)
-* [Software Changes from release to release](sw_changes_1.12.md)
-* [API Compatibility Macros in HDF5](https://docs.hdfgroup.org/hdf5/develop/api-compat-macros.html)
+* [New Features in 1.12](new_features_1_12.html)
+* [Software Changes from release to release](sw_changes_1.12.html)
+* [API Compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html)
 
 ## Compiling 1.10 and earlier applications with 1.12
 
@@ -38,7 +38,7 @@ Autotools:
 ./configure --with-default-api-version=v110
 
 CMake:
-If using the source code packaged with CMake configuration files (CMake-hdf5-1.12.0*), edit HDF5options.cmake, and add this line:
+If using the source code packaged with CMake configuration files (CMake-hdf5-1.12.0\*), edit HDF5options.cmake, and add this line:
 
 set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DDEFAULT_API_VERSION:STRING=v110")
 
@@ -56,7 +56,7 @@ Functions were modified in HDF5 version 1.12 to support a token type used in the
 The updated versions of the functions have a number (for eg '2' or '3') at the end of the original function name.   
 The original versions of these functions were retained and renamed to have an earlier number (for eg '1') at the end of the original function name.  
 A macro was created with the name of the original function.   
-Please read [API Compatibility Macros in HDF5](api_comp_macros.md) for more details on how the function names changed in version 1.12.
+Please read [API Compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html) for more details on how the function names changed in version 1.12.
 ~~~
 
 ## Token Type
@@ -81,7 +81,7 @@ This change affected the following functions:
 |                                                 |                                      |                                 |
 
 ## Encoding Properties
-These functions were introduced in HDF5 version 1.12 as part of the H5Sencode format change to enable 64-bit selection encodings and a dataspace selection that is tied to a file. See the [H5Sencode / H5Sdecode Format Change - RFC](https://docs.hdfgroup.org/hdf5/rfc/H5Sencode_format.docx.pdf) format change RFC for details.
+These functions were introduced in HDF5 version 1.12 as part of the H5Sencode format change to enable 64-bit selection encodings and a dataspace selection that is tied to a file. See the [H5Sencode / H5Sdecode Format Change - RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/H5Sencode_format.docx.pdf) format change RFC for details.
 
 | Original Function in 1.10/Maroc in 1.12 (H5xxx) | Deprecated Function in 1.12 (H5xxx1) | New Function (using token type) |
 | ----------------------------------------------- | ------------------------------------ | ------------------------------- |

--- a/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.12_to_HDF5_1.14.md
+++ b/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.12_to_HDF5_1.14.md
@@ -7,7 +7,7 @@ redirect_from:
 # Migrating to HDF5 1.14 from Previous Versions of HDF5
 
 ## API Changes
-There are new API calls that require API Compatibility Macros in HDF5 1.14.0. There are, however, two API calls which have had their signature change.
+There are new API calls that require [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 1.14.0. There are, however, two API calls which have had their signature change.
 
 ### `H5Iregister_type()` / `H5I_free_t`
 The signature of `H5Iregister_type()` did not change, but the `H5I_free_t` callback it accepts did have its signature change to add an asynchronous request parameter. There is no API compatibility macro to paper over this change. The request parameter can be ignored in the callback if you are not concerned with asynchronous operations and future IDs. A description of how the request parameter should be used will be found in the (soon to be released) HDF5 Asynchronous Programming Guide.

--- a/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.8_to_HDF5_1.10.md
+++ b/documentation/hdf5-docs/release_specifics/Migrating_from_HDF5_1.8_to_HDF5_1.10.md
@@ -12,7 +12,7 @@ Please follow these steps for moving your HDF5 application to HDF5 1.10:
 
 1. Make sure the latest (1.1.0.5+)  version of HDF5 1.10 is installed on your system. You can download the HDF5 1.10 release source code or pre-built binaries from [The HDF Group ftp server](https://support.hdfgroup.org/ftp/HDF5/prev-releases/hdf5-1.10/) and follow the included installation instructions.
 
-2. If on Unix, you can recompile and relink your application with HDF5 1.10, by using the h5cc script with any compiler flags needed for your application. The h5cc script can be found under the bin sub-directory of the HDF5 1.10 installation point.  In cases where your software package has a more complex build system and dependencies, just make sure you point to the new HDF5 1.10.* library when rebuilding your software.
+2. If on Unix, you can recompile and relink your application with HDF5 1.10, by using the h5cc script with any compiler flags needed for your application. The h5cc script can be found under the bin sub-directory of the HDF5 1.10 installation point.  In cases where your software package has a more complex build system and dependencies, just make sure you point to the new HDF5 1.10.\* library when rebuilding your software.
 
 3. If your application or software package has any regression test suite, run it and make sure that all tests pass.
 
@@ -22,7 +22,7 @@ If you have concerns about the files created by the rebuilt application (or soft
 
 1. Use the tools you regularly work with to open, browse, and modify the files created by the rebuilt application (for example, HDFView, MATLAB, IDL, etc.).
 
-2. If you have an HDF5 1.8.* installation on your system, use h5dump from that installation to read files created by the rebuilt application. If you encounter any errors, please rerun h5dump with the  "--enable-error-stack” flag and report the issue.
+2. If you have an HDF5 1.8.\* installation on your system, use h5dump from that installation to read files created by the rebuilt application. If you encounter any errors, please rerun h5dump with the  "--enable-error-stack” flag and report the issue.
 
 3. If you have files created by your application that were built with HDF5 1.8, use h5diff from the HDF5 1.8 installation to compare with the files created by the rebuilt application.
 
@@ -39,16 +39,16 @@ HDF5 1.8 will not be supported after the May 2020 release, i.e., there will be n
 
 In addition, applications originally written for use with HDF5 Release 1.8.x can be linked against the HDF5 Release 1.10.x library, thus taking advantage of performance improvements in 1.10. Users are encouraged to move to the latest releases of HDF5 1.10 or to HDF5 1.12.0 (coming out in the summer of 2019) if they want to stay with the current HDF5 upgrades.
 
-If you are not planning to upgrade your system environment, and a version of HDF5 1.8.* works for you, then there is no reason to upgrade to the latest HDF5. However, if you regularly update your software to use the latest HDF5 1.8 maintenance release, then you need to plan a transition to HDF5 1.10 after the HDF5 1.8 May 2020 release.
+If you are not planning to upgrade your system environment, and a version of HDF5 1.8.\* works for you, then there is no reason to upgrade to the latest HDF5. However, if you regularly update your software to use the latest HDF5 1.8 maintenance release, then you need to plan a transition to HDF5 1.10 after the HDF5 1.8 May 2020 release.
  
 
 ### Why do I need to rebuild my application with HDF5 1.10?
 
-The HDF5 1.10.* binaries are not ABI compatible with the HDF5 1.8.* binaries due to changes in the public header files and APIs. One has to rebuild an application with the HDF5 1.10.* library. The HDF Group tries hard to maintain ABI compatibility for minor maintenance releases, for example when moving from 1.8.21 to 1.8.22, or 1.10.5 to 1.10.6, but this is not the case when migrating from one major release to another, for example, from 1.8.21 to 1.10.5. If you want to learn more about HDF5 versioning please see HDF5 Library Release Version Numbers.
+The HDF5 1.10.\* binaries are not ABI compatible with the HDF5 1.8.\* binaries due to changes in the public header files and APIs. One has to rebuild an application with the HDF5 1.10.\* library. The HDF Group tries hard to maintain ABI compatibility for minor maintenance releases, for example when moving from 1.8.21 to 1.8.22, or 1.10.5 to 1.10.6, but this is not the case when migrating from one major release to another, for example, from 1.8.21 to 1.10.5. If you want to learn more about HDF5 versioning please see HDF5 Library Release Version Numbers.
 
 ### Can I migrate my application if I still use the HDF5 1.6 APIs?
 
-Yes, use the -DH5_USE_16_API compiler flag. For more information see the [API compatibility Macros in HDF5](api_comp_macros.md) document.
+Yes, use the -DH5_USE_16_API compiler flag. For more information see the [API compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html) document.
 
 ### Will my old software read files created by an application rebuilt with HDF5 1.10?
 

--- a/documentation/hdf5-docs/release_specifics/additional_APIs.md
+++ b/documentation/hdf5-docs/release_specifics/additional_APIs.md
@@ -12,7 +12,7 @@ Versioned Functions and Struct with Associated Macros
 Property List Encoding and Decoding Functions
 External File Prefix Functions
 Versioned Functions and Struct with Associated Macros
-Two functions in the HDF5 C interface, and a struct associated with one of those functions, have been versioned in this release. At the same time, interface compatibility macros were created for programmatic management of these functions. See API Compatibility Macros in HDF5 for a detailed discussion of versioned functions and structs and the related macros.
+Two functions in the HDF5 C interface, and a struct associated with one of those functions, have been versioned in this release. At the same time, interface compatibility macros were created for programmatic management of these functions. See [API Compatibility Macros in HDF5](/documentation/hdf5/latest/api-compat-macros.html) for a detailed discussion of versioned functions and structs and the related macros.
 
 These functions, struct, and macros are documented in the HDF5 Reference Manual:
 

--- a/documentation/hdf5-docs/release_specifics/hdf5_1_10.md
+++ b/documentation/hdf5-docs/release_specifics/hdf5_1_10.md
@@ -11,10 +11,10 @@ redirect_from:
 ### [New Features in HDF5 Release 1.10](new_features_1_10.html)
 
 * [Additional New APIs](additional_APIs.html)
-* [Chunk Query Functionality (RFC)](https://docs.hdfgroup.org/hdf5/rfc/RFC-Chunking%20Functions-2018-06-20-v3.docx.pdf)
-* [Minimum Object Headers (RFC)](https://docs.hdfgroup.org/hdf5/rfc/RFC_Min_Obj_Headers_181231.pdf)
-* [Parallel Library Change (RFC)](https://docs.hdfgroup.org/hdf5/develop/_r_f_c.html)
-* [Read Proc0 and Bcast (RFC)](https://docs.hdfgroup.org/hdf5/rfc/3.2.1_3.2.2_deliverable_181220_v4.pdf)
-* [Setting Bounds for Object Creation in HDF5-1.10.0 - RFC](https://docs.hdfgroup.org/hdf5/rfc/RFC-bounds.pdf)
+* [Chunk Query Functionality (RFC)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC-Chunking%20Functions-2018-06-20-v3.docx.pdf)
+* [Minimum Object Headers (RFC)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC_Min_Obj_Headers_181231.pdf)
+* [Parallel Library Change (RFC)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc)
+* [Read Proc0 and Bcast (RFC)](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/3.2.1_3.2.2_deliverable_181220_v4.pdf)
+* [Setting Bounds for Object Creation in HDF5-1.10.0 - RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC-bounds.pdf)
 
 ### [Software Changes from Release to Release for HDF5-1.10](sw_changes_1.10.html)

--- a/documentation/hdf5-docs/release_specifics/hdf5_1_12.md
+++ b/documentation/hdf5-docs/release_specifics/hdf5_1_12.md
@@ -6,14 +6,14 @@ redirect_from:
 
 # HDF5 1.12
 
-### [Migrating from HDF5 1.10 to HDF5 1.12](Migrating_from_HDF5_1.10_to_HDF5_1.12.md)
+### [Migrating from HDF5 1.10 to HDF5 1.12](Migrating_from_HDF5_1.10_to_HDF5_1.12.html)
 
-### [New Features in HDF5 Release 1.12](new_features_1_12.md)
+### [New Features in HDF5 Release 1.12](new_features_1_12.html)
 
-* [H5Sencode / H5Sdecode Format Change - RFC](https://docs.hdfgroup.org/hdf5/rfc/H5Sencode_format.docx.pdf)
-* [Update to References](https://docs.hdfgroup.org/hdf5/rfc/RFC_Update_to_HDF5_References.pdf)
-* [Update to Selections](https://docs.hdfgroup.org/hdf5/rfc/selection_io_RFC_210610.pdf)
-* [Virtual Object Layer](https://docs.hdfgroup.org/hdf5/develop/_v_o_l__connector.html)
-* [Hyperslab Performance Improvement](need link Hyperslab-Performance-Improvements)
+* [H5Sencode / H5Sdecode Format Change - RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/H5Sencode_format.docx.pdf)
+* [Update to References](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC_Update_to_HDF5_References.pdf)
+* [Update to Selections](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/selection_io_RFC_210610.pdf)
+* [Virtual Object Layer](https://support.hdfgroup.org/documentation/hdf5/latest/_v_o_l__connector.html)
+* Hyperslab Performance Improvement
 
-### [Software Changes from Release to Release for HDF5 1.12](sw_changes_1.12.md)
+### [Software Changes from Release to Release for HDF5 1.12](sw_changes_1.12.html)

--- a/documentation/hdf5-docs/release_specifics/hdf5_1_14.md
+++ b/documentation/hdf5-docs/release_specifics/hdf5_1_14.md
@@ -6,9 +6,9 @@ redirect_from:
 
 # HDF5 1.14
 
-### [Migrating from HDF5 1.12 to HDF5 1.14](Migrating_from_HDF5_1.12_to_HDF5_1.14.md)
+### [Migrating from HDF5 1.12 to HDF5 1.14](Migrating_from_HDF5_1.12_to_HDF5_1.14.html)
 
-### [New Features in HDF5 Release 1.14](new_features_1_14.md)
+### [New Features in HDF5 Release 1.14](new_features_1_14.html)
  
 * [16 bit floating point and Complex number datatypes](https://github.com/HDFGroup/hdf5doc/blob/master/RFCs/HDF5_Library/Float16/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf)
 * [Asynchronous I/O operations](asyn_ops_wHDF5_VOL_connectors.html)
@@ -16,4 +16,4 @@ redirect_from:
 * [Onion VFD](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/Onion_VFD_RFC_211122.pdf)
 * [Multi Dataset I/O](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/H5HPC_MultiDset_RW_IO_RFC.pdf)
 
-### [Software Changes from Release to Release for HDF5 1.14](sw_changes_1.14.md)
+### [Software Changes from Release to Release for HDF5 1.14](sw_changes_1.14.html)

--- a/documentation/hdf5-docs/release_specifics/hdf5_1_8.md
+++ b/documentation/hdf5-docs/release_specifics/hdf5_1_8.md
@@ -6,6 +6,6 @@ redirect_from:
 
 # HDF5 1.8
 
-### [New Features in HDF5 Release 1.8](new_features_1_8.md)
+### [New Features in HDF5 Release 1.8](new_features_1_8.html)
 
-### [Software Changes from Release to Release for HDF5-1.8](sw_changes_1.8.md)
+### [Software Changes from Release to Release for HDF5-1.8](sw_changes_1.8.html)

--- a/documentation/hdf5-docs/release_specifics/new_features_1_10.md
+++ b/documentation/hdf5-docs/release_specifics/new_features_1_10.md
@@ -8,13 +8,13 @@ redirect_from:
 
 HDF5 1.10 introduces several new features in the HDF5 library. These new features were added in the first three releases of HDF5-1.10. For a brief description of each new feature see:
 
-* [New Features Introduced in HDF5 1.10.8](#new-features-introduced-in-hdf5-1.10.8)
-* [New Features Introduced in HDF5 1.10.7](#new-features-introduced-in-hdf5-1.10.7)
-* [New Features introduced in HDF5 1.10.6](#new-features-introduced-in-hdf5-1.10.6)
-* [New Features introduced in HDF5 1.10.5](#new-features-introduced-in-hdf5-1.10.5)
-* [New Features Introduced in HDF5 1.10.2](#new-features-introduced-in-hdf5-1.10.2)
-* [New Features Introduced in HDF5 1.10.1](#new-features-introduced-in-hdf5-1.10.1)
-* [New Features Introduced in HDF5 1.10.0](#new-features-introduced-in-hdf5-1.10.0)
+* <a href="#newin8">New Features Introduced in HDF5 1.10.8</a>
+* <a href="#newin7">New Features Introduced in HDF5 1.10.7</a>
+* <a href="#newin6">New Features introduced in HDF5 1.10.6</a>
+* <a href="#newin5">New Features introduced in HDF5 1.10.5</a>
+* <a href="#newin2">New Features Introduced in HDF5 1.10.2</a>
+* <a href="#newin1">New Features Introduced in HDF5 1.10.1</a>
+* <a href="#newin0">New Features Introduced in HDF5 1.10.0</a>
 
 ~~~
 This release includes changes in the HDF5 storage format. For detailed information on the changes, see: Changes to the File Format Specification
@@ -28,10 +28,10 @@ Due to the requirements of some of the new features, the format of a 1.10.x HDF5
 If an application built on HDF5 Release 1.10 avoids use of the new features and does not request use of the latest format, applications built on HDF5 Release 1.8.x will be able to read files the first application created. In addition, applications originally written for use with HDF5 Release 1.8.x can be linked against a suitably configured HDF5 Release 1.10.x library, thus taking advantage of performance improvements in 1.10.
 ~~~
 
-## New Features Introduced in HDF5 1.10.8
+<h2 id="newin8">New Features Introduced in HDF5 1.10.8</h2>
 The following important new features and changes were introduced in HDF5-1.10.8. For complete details see the Release Notes and the Software Changes from Release to Release page.
 
-## New Features Introduced in HDF5 1.10.7
+<h2 id="newin7">New Features Introduced in HDF5 1.10.7</h2>
 The following important new features and changes were introduced in HDF5-1.10.7. For complete details see the Release Notes and the Software Changes from Release to Release page.
 
 Addition of AEC (open source SZip) Compression Library
@@ -48,7 +48,7 @@ Performance has continued to improve in this release. Please see the images unde
 Addition of Hyperslab Selection Functions
 Several hyperslab selection routines introduced in HDF5-1.12 were ported to 1.10. See the Software Changes from Release to Release page for details.
                                                                                                 
-## New Features Introduced in HDF5 1.10.6
+<h2 id="newin6">New Features Introduced in HDF5 1.10.6</h2>
 The following important new features and changes were introduced in HDF5-1.10.6. For complete details see the Release Notes and the Software Changes from Release to Release page:
 
 ### Improvements to the CMake Support
@@ -67,7 +67,7 @@ See the Virtual File Drivers - S3 and HDFS page for more information.
 ### Improvement to Performance
 Performance was improved when creating a large number of small datasets.
 
-## New Features Introduced in HDF5 1.10.5
+<h2 id="newin5">New Features Introduced in HDF5 1.10.5</h2>
 The following important new features were added in HDF5-1.10.5. Please see the release announcement and Software Changes from Release to Release page for more details regarding these features:
 
 ### Minimized Dataset Object Headers (RFC)
@@ -122,7 +122,7 @@ H5D_GET_CHUNK_INFO  Retrieves information about a chunk specified by the chunk i
 H5D_GET_CHUNK_INFO_BY_COORD Retrieves information about a chunk specified by its coordinates
 H5D_GET_NUM_CHUNKS  Retrieves number of chunks that have nonempty intersection with a specified selection
 
-## New Features Introduced in HDF5 1.10.2
+<h2 id="newin2">New Features Introduced in HDF5 1.10.2</h2>
 Several important features and changes were added to HDF5 1.10.2. See the release announcement and blog for complete details. Following are the major new features:
 
 ### Forward Compatibility for HDF5 1.8-based Applications Accessing Files Created by HDF5 1.10.2 ( RFC )
@@ -136,7 +136,7 @@ Optimizations were introduced to parallel HDF5 for improving the performance of 
 HDF5 parallel applications can now write data using compression (and other filters such as the Fletcher32 checksum filter).
 
 
-## New Features Introduced in HDF5 1.10.1
+<h2 id="newin1">New Features Introduced in HDF5 1.10.1</h2>
 
 ### Metadata Cache Image ( RFC ) -> Fine-tuning the Metadata Cache *
 HDF5 metadata is typically small, and scattered throughout the HDF5 file. This can affect performance, particularly on large HPC systems. The Metadata Cache Image feature can improve performance by writing the metadata cache in a single block on file close, and then populating the cache with the contents of this block on file open, thus avoiding the many small I/O operations that would otherwise be required on file open and close.
@@ -153,7 +153,7 @@ Small and random I/O accesses on parallel file systems result in poor performanc
 
 
 
-## New Features Introduced in HDF5 1.10.0
+<h2 id="newin0">New Features Introduced in HDF5 1.10.0</h2>
 
 ### SWMR *
 Data acquisition and computer modeling systems often need to analyze and visualize data while it is being written. It is not unusual, for example, for an application to produce results in the middle of a run that suggest some basic parameters be changed, sensors be adjusted, or the run be scrapped entirely.

--- a/documentation/hdf5-docs/release_specifics/new_features_1_12.md
+++ b/documentation/hdf5-docs/release_specifics/new_features_1_12.md
@@ -10,27 +10,30 @@ This release includes changes in the HDF5 storage format. PLEASE NOTE that HDF5-
 
 HDF5 1.12 introduces several new features in the HDF5 library:
 
-* [H5Sencode / H5Sdecode Format Change - RFC](https://docs.hdfgroup.org/hdf5/rfc/H5Sencode_format.docx.pdf)
-* [Update to References](https://docs.hdfgroup.org/hdf5/rfc/RFC_Update_to_HDF5_References.pdf)
-* [Update to Selections](https://docs.hdfgroup.org/hdf5/rfc/selection_io_RFC_210610.pdf)
-* [Virtual Object Layer](https://docs.hdfgroup.org/hdf5/develop/_v_o_l__connector.html)
-* [Hyperslab Performance Improvement](#Hyperslab-Performance-Improvements)
+* <a href="#encode-decode">H5Sencode / H5Sdecode Format Change</a>
+<a href="#vol">Virtual Object Layer (VOL)</a>
+<a href="#references">Update to References</a>
+<a href="#selections">Update to Selections</a>
+<a href="#hyperslab">Hyperslab Performance Improvement</a>
 
-## Virtual Object Layer (VOL)  (RFC)
+<h2 id="encode-decode">H5Sencode / H5Sdecode Format Change</h2>
 
-See the [Virtual Object Layer](https://docs.hdfgroup.org/hdf5/develop/_h5_v_l__u_g.html#sec_vol) page for more information.
+Several new H5S APIs were introduced to allow a user to more flexibly operate on two hyperslab selections.  See the [Selection I/O update RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/H5Sencode_format.docx.pdf) for details.
+
+
+<h2 id="vol">Virtual Object Layer (VOL)</h2>
 
 The Virtual Object Layer (VOL) is an abstraction layer within the HDF5 library that enables different methods for accessing data and objects that conform to the HDF5 data model. The VOL intercepts all HDF5 API calls that potentially modify data on disk and forwards those calls to a plugin "object driver". The data on disk can be a different format than the HDF5 format.
 
 
-
 The plugins can actually store the objects in variety of ways. A plugin could, for example, have objects be distributed remotely over different platforms, provide a raw mapping of the model to the file system, or even store the data in other file formats (like native netCDF or HDF4 format). The user still gets the same data model where access is done to a single HDF5 \"container\"; however the plugin object driver translates from what the user sees to how the data is actually stored. Having this abstraction layer maintains the object model of HDF5 and allows better usage of new object storage file systems that are targeted for Exascale systems.
 
-## Hyperslab Performance Improvements
-In 1.12.0 the hyperslab selection code was optimized to achieve better performance. In general, performance improved by an order of a magnitude. In the case of reading a regular selection from a 20 GB dataset into a one dimensional array, performance improved by a factor of 6000. If you are interested in the benchmark we ran, please see issue HDFFV-10930 by logging into jira.hdfgroup.org with your hdfgroup.org login.
+See the [Virtual Object Layer](/documentation/hdf5/latest/_h5_v_l__u_g.html#sec_vol) page for more information.
 
-## Update to References (RFC) *
-See the Update to References page for details on the changes in HDF5-1.12.
+
+<h2 id="references">Update to References</h2>
+
+See the [References update RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/RFC_Update_to_HDF5_References.pdf) for details on the changes in HDF5-1.12.
 
 HDF5 references were extended to support attributes, as well as object and dataset selections that reside in another HDF5 file. In order to support these features several functions were introduced:
 
@@ -39,5 +42,11 @@ HDF5 references were extended to support attributes, as well as object and datas
 * Functions were added to query references (H5R_GET\*).
 * Other functions were added to simplify or clarify the API.
 
-## Update to Selections
-Several new H5S APIs were introduced to allow a user to more flexibly operate on two hyperslab selections. See Update to Selections for more details.
+<h2 id="selections">Update to Selections</h2>
+
+Several new H5S APIs were introduced to allow a user to more flexibly operate on two hyperslab selections.  See the [Selection I/O update RFC](https://support.hdfgroup.org/releases/hdf5/documentation/rfc/selection_io_RFC_210610.pdf) for details.
+
+<h2 id="hyperslab">Hyperslab Performance Improvements</h2>
+
+In 1.12.0 the hyperslab selection code was optimized to achieve better performance. In general, performance improved by an order of a magnitude. In the case of reading a regular selection from a 20 GB dataset into a one dimensional array, performance improved by a factor of 6000. If you are interested in the benchmark we ran, please see issue HDFFV-10930 by logging into jira.hdfgroup.org with your hdfgroup.org login.
+

--- a/documentation/hdf5-docs/release_specifics/sw_changes_1.10.md
+++ b/documentation/hdf5-docs/release_specifics/sw_changes_1.10.md
@@ -30,7 +30,7 @@ The following information is included below.
 * <a href="#1versus0">Release 1.10.1 versus Release 1.10.0 (and 1.10.0-patch1)</a>
 * <a href="#0versus8_16">Release 1.10.0 of March 2016 versus Release 1.8.16</a>
 
-See [API Compatibility Reports for 1.10]() for information regarding compatibility with previous releases.
+See [API Compatibility Reports for 1.10](/documentation/hdf5/latest/api-compat-macros.html) for information regarding compatibility with previous releases.
 
 <h2 id="compatibility">Compatibility and Performance Issues</h2>
 
@@ -93,20 +93,20 @@ The following are new C functions in this release:
 
 | Function                      | Description                                               |
 | ----------------------------- | --------------------------------------------------------- |
-| [H5Pget\_fapl\_splitter](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list    |
-| [H5Pget\_fapl_splitter](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list    |
-| [H5Pset\_fapl_splitter](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga49f386ea235bb48128e54c962c499f07) | Sets the file access property list to use the splitter driver     |
-| [H5Pget\_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) | Gets the file locking property values |
-| [H5Pset\_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) | Sets the file locking property values |
-| [H5get\_free_list_sizes](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5.html#ga2310d963a6f48ec12fda8c0c8bbefbbb) | Gets the current size of the free lists used to manage memory  |
-| [H5Scombine_hyperslab](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#gae7578a93bb7b22989bcb737f26b60ad1) | Performs an operation on a hyperslab and an existing selection and returns the resulting selection |
-| [H5Scombine_select](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga356600d12d3cf0db53cc27b212d75b08) | Combines two hyperslab selections with an operation, returning a dataspace with the resulting selection |
-| [H5Smodify_select](https://support.hdfgroup.org/documentation/hdf5/latest/group___j_h5_s.html#ga814b2cb29fcdfe79892737f4337d0ef9) | Refines a hyperslab selection with an operation using a second hyperslab to modify it |
-| [H5Sselect_adjust](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga64f08c187b899f2728d4ac016d44f890) | Adjusts a selection by subtracting an offset |
-| [H5Sselect_copy](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga57e5eba2d1b282803835ba3f7e0b9bfa) | Copies a selection from one dataspace to another |
-| [H5Sselect_intersect_block](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga51472bcb9af024675fba6294a6aefa5e) | Checks if current selection intersects with a block |
-| [H5Sselect_project_intersection](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga1e914ba45afb15ded99a0afeaf124c04) | Projects the intersection of two source selections to a destination selection |
-| [H5Sselect_shape_same](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#gafc6cafae877900ee060709eaa0b9b261) | Checks if two selections are the same shape |
+| [H5Pget\_fapl\_splitter](/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list    |
+| [H5Pget\_fapl_splitter](/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list    |
+| [H5Pset\_fapl_splitter](/documentation/hdf5/latest/group___f_a_p_l.html#ga49f386ea235bb48128e54c962c499f07) | Sets the file access property list to use the splitter driver     |
+| [H5Pget\_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) | Gets the file locking property values |
+| [H5Pset\_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) | Sets the file locking property values |
+| [H5get\_free_list_sizes](/documentation/hdf5/latest/group___h5.html#ga2310d963a6f48ec12fda8c0c8bbefbbb) | Gets the current size of the free lists used to manage memory  |
+| [H5Scombine_hyperslab](/documentation/hdf5/latest/group___h5_s.html#gae7578a93bb7b22989bcb737f26b60ad1) | Performs an operation on a hyperslab and an existing selection and returns the resulting selection |
+| [H5Scombine_select](/documentation/hdf5/latest/group___h5_s.html#ga356600d12d3cf0db53cc27b212d75b08) | Combines two hyperslab selections with an operation, returning a dataspace with the resulting selection |
+| [H5Smodify_select](/documentation/hdf5/latest/group___j_h5_s.html#ga814b2cb29fcdfe79892737f4337d0ef9) | Refines a hyperslab selection with an operation using a second hyperslab to modify it |
+| [H5Sselect_adjust](/documentation/hdf5/latest/group___h5_s.html#ga64f08c187b899f2728d4ac016d44f890) | Adjusts a selection by subtracting an offset |
+| [H5Sselect_copy](/documentation/hdf5/latest/group___h5_s.html#ga57e5eba2d1b282803835ba3f7e0b9bfa) | Copies a selection from one dataspace to another |
+| [H5Sselect_intersect_block](/documentation/hdf5/latest/group___h5_s.html#ga51472bcb9af024675fba6294a6aefa5e) | Checks if current selection intersects with a block |
+| [H5Sselect_project_intersection](/documentation/hdf5/latest/group___h5_s.html#ga1e914ba45afb15ded99a0afeaf124c04) | Projects the intersection of two source selections to a destination selection |
+| [H5Sselect_shape_same](/documentation/hdf5/latest/group___h5_s.html#gafc6cafae877900ee060709eaa0b9b261) | Checks if two selections are the same shape |
 
 #### In the C++ API
 
@@ -116,7 +116,7 @@ The following C++ wrappers were added:
 | FileAccPropList::setFileLocking | See H5Pset\_FILE\_LOCKING for details |
 
 ### Compatibility Notes and Reports
-See the [API compatibility report between 1.10.7 and 1.10.8]() for information regarding compatibility with the previous release.
+See the [API compatibility report between 1.10.6 and 1.10.7](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.7-interface_compatibility_report.html) for information regarding compatibility with the previous release.
 
 <h2 id="6versus5">Release 1.10.6 versus 1.10.5</h2>
 
@@ -127,10 +127,10 @@ The following are new C functions in this release:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Pget\_fapl_hdfs](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gae59e7d8e0e8823e6dd6034b66418ed00) | Gets the information of the given Read-Only HDFS virtual file driver |
-| [H5Pget\_fapl_ros3](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga13e273711e160cbd58e60c701b4f50e6) | Gets the information of the given Read-Only S3 virtual file driver |
-| [H5Pset\_fapl_hdfs](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga970d077c8e712a4692f43fa4f38dde14) | Sets up Read-Only HDFS virtual file driver |
-| [H5Pset\_fapl_ros3](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaad28d8c24f236590193215c5ae7a8f18) | Sets up Read-Only S3 virtual file driver |
+| [H5Pget\_fapl_hdfs](/documentation/hdf5/latest/group___f_a_p_l.html#gae59e7d8e0e8823e6dd6034b66418ed00) | Gets the information of the given Read-Only HDFS virtual file driver |
+| [H5Pget\_fapl_ros3](/documentation/hdf5/latest/group___f_a_p_l.html#ga13e273711e160cbd58e60c701b4f50e6) | Gets the information of the given Read-Only S3 virtual file driver |
+| [H5Pset\_fapl_hdfs](/documentation/hdf5/latest/group___f_a_p_l.html#ga970d077c8e712a4692f43fa4f38dde14) | Sets up Read-Only HDFS virtual file driver |
+| [H5Pset\_fapl_ros3](/documentation/hdf5/latest/group___f_a_p_l.html#gaad28d8c24f236590193215c5ae7a8f18) | Sets up Read-Only S3 virtual file driver |
  
 #### In the C++ API
 
@@ -138,11 +138,11 @@ The following C++ wrappers were added:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| LinkCreatPropList::getCreateIntermediateGroup() const | See [H5Pget\_create_intermediate_group](https://support.hdfgroup.org/documentation/hdf5/latest/group___l_c_p_l.html#gaf7db1b7ce19703f30f1827b7c899c3b0) |
-| LinkCreatPropList::setCreateIntermediateGroup(bool crt\_intmd\_group) const | See [H5Pset\_create_intermediate_group](https://support.hdfgroup.org/documentation/hdf5/latest/group___l_c_p_l.html#ga66c4c5d3f34e5cf65d00e47a5387383c) |
+| LinkCreatPropList::getCreateIntermediateGroup() const | See [H5Pget\_create_intermediate_group](/documentation/hdf5/latest/group___l_c_p_l.html#gaf7db1b7ce19703f30f1827b7c899c3b0) |
+| LinkCreatPropList::setCreateIntermediateGroup(bool crt\_intmd\_group) const | See [H5Pset\_create_intermediate_group](/documentation/hdf5/latest/group___l_c_p_l.html#ga66c4c5d3f34e5cf65d00e47a5387383c) |
 
 ### Compatibility Notes and Reports
-See the [API compatibility report between 1.10.7 and 1.10.8]() for information regarding compatibility with the previous release.
+See the [API compatibility report between 1.10.5 and 1.10.6](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for information regarding compatibility with the previous release.
 
 <h2 id="5versus4">Release 1.10.5 versus 1.10.4</h2>
 
@@ -153,20 +153,20 @@ The following are new C functions in this release:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Dget\_chunk_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d.html#gaccff213d3e0765b86f66d08dd9959807) | Retrieves information about a chunk specified by the chunk index |
-| [H5Dget\_chunk_info_by_coord](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d.html#ga408a49c6ec59c5b65ce4c791f8d26cb0) | Retrieves information about a chunk specified by its coordinates |
-| [H5Dget\_num_chunks](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d.html#ga8e15897dcc5799d6c09806644b492d7a) | Retrieves number of chunks that have nonempty intersection with a specified selection |
-| [H5Fget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4) | Retrieves the setting for determining whether the specified file does or does not create minimized dataset object headers |
-| [H5Fset\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c) |Sets the flag to create minimized dataset object headers |
-| [H5Pget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970) |Retrieves the setting for determining whether the specified DCPL does or does not create minimized dataset object headers |
-| [H5Pset\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#gaf5ae8c0257c02e3fbe50bde70b1eb8be) |Sets the flag to create minimized dataset object headers |
+| [H5Dget\_chunk_info](/documentation/hdf5/latest/group___h5_d.html#gaccff213d3e0765b86f66d08dd9959807) | Retrieves information about a chunk specified by the chunk index |
+| [H5Dget\_chunk_info_by_coord](/documentation/hdf5/latest/group___h5_d.html#ga408a49c6ec59c5b65ce4c791f8d26cb0) | Retrieves information about a chunk specified by its coordinates |
+| [H5Dget\_num_chunks](/documentation/hdf5/latest/group___h5_d.html#ga8e15897dcc5799d6c09806644b492d7a) | Retrieves number of chunks that have nonempty intersection with a specified selection |
+| [H5Fget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4) | Retrieves the setting for determining whether the specified file does or does not create minimized dataset object headers |
+| [H5Fset\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c) |Sets the flag to create minimized dataset object headers |
+| [H5Pget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970) |Retrieves the setting for determining whether the specified DCPL does or does not create minimized dataset object headers |
+| [H5Pset\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___d_c_p_l.html#gaf5ae8c0257c02e3fbe50bde70b1eb8be) |Sets the flag to create minimized dataset object headers |
  
 
 The following changed in this release:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Oget\_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaf4f302a33faba9e1c2b5f64c62ca4ed5)<br>[H5Oget\_info_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga16d8ac07f9244cfccb42b5f309ca6b3c)<br>[H5Oget\_info_by_idx](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gafe764884e1530f86079288dd5895a7bd)<br>[H5Ovisit](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga5ce86255fcc34ceaf84a62551cd24233)<br>[H5Ovisit_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c) | In 1.10.3 the original functions were versioned to H5Oget\_info*1 and H5Ovisit*1 and the macros H5Oget\_info* and H5Ovisit* were created. This broke the API compatibility for a maintenance release. In HDF5-1.10.5, the macros introduced in HDF5-1.10.3 were removed. The H5Oget\_info*1 and H5Ovisit*1 APIs were copied to H5Oget\_Info* and H5Ovisit*. As an example, H5Oget\_info and H5Oget\_info1 are identical in this release. |
+| [H5Oget\_info](/documentation/hdf5/latest/group___h5_o.html#gaf4f302a33faba9e1c2b5f64c62ca4ed5)<br>[H5Oget\_info_by_name](/documentation/hdf5/latest/group___h5_o.html#ga16d8ac07f9244cfccb42b5f309ca6b3c)<br>[H5Oget\_info_by_idx](/documentation/hdf5/latest/group___h5_o.html#gafe764884e1530f86079288dd5895a7bd)<br>[H5Ovisit](/documentation/hdf5/latest/group___h5_o.html#ga5ce86255fcc34ceaf84a62551cd24233)<br>[H5Ovisit_by_name](/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c) | In 1.10.3 the original functions were versioned to H5Oget\_info*1 and H5Ovisit*1 and the macros H5Oget\_info* and H5Ovisit* were created. This broke the API compatibility for a maintenance release. In HDF5-1.10.5, the macros introduced in HDF5-1.10.3 were removed. The H5Oget\_info*1 and H5Ovisit*1 APIs were copied to H5Oget\_Info* and H5Ovisit*. As an example, H5Oget\_info and H5Oget\_info1 are identical in this release. |
 
 #### In the C++ API
 
@@ -182,8 +182,8 @@ The following Fortran wrappers were added or changed:
 
 | Function          | Description   |
 | ----------------- | --------------|
-| [h5fget\_dset\_no\_attrs\_hint\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#gaceb86e903eddc57846c8a249ab5b0a66)<br> [h5fset\_dset\_no\_attrs\_hint\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#gafda7e4a737f10a9be280afcdbf468e61)<br> [h5pget\_dset\_no\_attrs\_hint\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_p.html#ga7cc4d157c8502632af18454424aa58d6)<br> [h5pset\_dset\_no\_attrs\_hint\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_p.html#ga3b2e599c1c38c395d6d9b1cdddee4f6a) | Wrappers for the dataset object header minimization calls. See [H5Fget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4), [H5Fset\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c), [H5Pget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970), and [H5Pset\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#gaf5ae8c0257c02e3fbe50bde70b1eb8be). |
-| [h5ovisit\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html#ga1aa4f84b78f029f048593b1ec0757a63)<br>[h5oget\_info\_by\_name\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html#ga40081a5f47dc7900a795c0df62791ff7)<br>[h5oget\_info\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html#gabdbe70d333edbc46cffd791495e3edea)<br>[h5oget\_info\_by\_idx\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html#ga6666adcfef409c0828390b75730f9987)<br>[h5ovisit\_by\_name\_f](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_o.html#gaed6f1ee04db6973cbffca2cf0c33348f)<br>| Added new Fortran 'fields' optional parameter. See [H5Ovisit2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaa4ab542f581f4fc9a4eaa95debb29c9e), [H5Oget\_info_by_name2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga0090da86c086c1c63a5acfaed39a035e), [H5Oget\_info2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga06f896e14fe4fa940fbc2bc235e0cf74), [H5Oget\_info_by_idx2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga85e15e65922874111da1a5efd5dd7bed), and [H5Ovisit_by_name2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga9c155caf5499405fe403e1eb27b5beb6). |
+| [h5fget\_dset\_no\_attrs\_hint\_f](/documentation/hdf5/latest/group___f_h5_f.html#gaceb86e903eddc57846c8a249ab5b0a66)<br> [h5fset\_dset\_no\_attrs\_hint\_f](/documentation/hdf5/latest/group___f_h5_f.html#gafda7e4a737f10a9be280afcdbf468e61)<br> [h5pget\_dset\_no\_attrs\_hint\_f](/documentation/hdf5/latest/group___f_h5_p.html#ga7cc4d157c8502632af18454424aa58d6)<br> [h5pset\_dset\_no\_attrs\_hint\_f](/documentation/hdf5/latest/group___f_h5_p.html#ga3b2e599c1c38c395d6d9b1cdddee4f6a) | Wrappers for the dataset object header minimization calls. See [H5Fget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4), [H5Fset\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c), [H5Pget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970), and [H5Pset\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___d_c_p_l.html#gaf5ae8c0257c02e3fbe50bde70b1eb8be). |
+| [h5ovisit\_f](/documentation/hdf5/latest/group___f_h5_o.html#ga1aa4f84b78f029f048593b1ec0757a63)<br>[h5oget\_info\_by\_name\_f](/documentation/hdf5/latest/group___f_h5_o.html#ga40081a5f47dc7900a795c0df62791ff7)<br>[h5oget\_info\_f](/documentation/hdf5/latest/group___f_h5_o.html#gabdbe70d333edbc46cffd791495e3edea)<br>[h5oget\_info\_by\_idx\_f](/documentation/hdf5/latest/group___f_h5_o.html#ga6666adcfef409c0828390b75730f9987)<br>[h5ovisit\_by\_name\_f](/documentation/hdf5/latest/group___f_h5_o.html#gaed6f1ee04db6973cbffca2cf0c33348f)<br>| Added new Fortran 'fields' optional parameter. See [H5Ovisit2](/documentation/hdf5/latest/group___h5_o.html#gaa4ab542f581f4fc9a4eaa95debb29c9e), [H5Oget\_info_by_name2](/documentation/hdf5/latest/group___h5_o.html#ga0090da86c086c1c63a5acfaed39a035e), [H5Oget\_info2](/documentation/hdf5/latest/group___h5_o.html#ga06f896e14fe4fa940fbc2bc235e0cf74), [H5Oget\_info_by_idx2](/documentation/hdf5/latest/group___h5_o.html#ga85e15e65922874111da1a5efd5dd7bed), and [H5Ovisit_by_name2](/documentation/hdf5/latest/group___h5_o.html#ga9c155caf5499405fe403e1eb27b5beb6). |
 
  
 The following Fortran utility function was added:
@@ -207,19 +207,19 @@ The following Java wrappers were added or changed:
 | Function          | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |
 | [H5Fset\_libver_bounds]() | See the C API  H5Fset\_libver_bounds for information on this function |
-| [H5Fget\_dset\_no_attrs_hint](documentation/doxygen/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4) | |
+| [H5Fget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4) | |
 | [H5Fset\_dset\_no_attrs_hint]() | |
 | [H5Pget\_dset\_no_attrs_hint]() | |
 | [H5Pset\_dset\_no_attrs_hint]() | |
 
-Wrappers for the dataset object header minimization calls  See [H5Fget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4), [H5Fset\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c), [H5Pget\_dset\_no_attrs_hint](https://support.hdfgroup.org/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970), and H5Pset\_DSET\_NO\_ATTRS\_HINT for more information on these APIs.
+Wrappers for the dataset object header minimization calls  See [H5Fget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gacbf3ba8b36750c42b49740567a9732c4), [H5Fset\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___h5_f.html#gafc0166070f920f037e6b1a5c66e5464c), [H5Pget\_dset\_no_attrs_hint](/documentation/hdf5/latest/group___d_c_p_l.html#ga2fd4f0446a38186db8256cef4c97a970), and H5Pset\_DSET\_NO\_ATTRS\_HINT for more information on these APIs.
 
 ### Compatibility Notes and Reports
-See the [API compatibility report between 1.10.5 and 1.10.2/1.10.3/1.10.4]() for details.
+See the [API compatibility report between 1.10.5 and 1.10.2/1.10.3/1.10.4](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for details.
 
 <h2 id="4versus3">Release 1.10.4 versus 1.10.3</h2>
 
-See the [API compatibility report between 1.10.4 and 1.10.3]() for details.
+See the [API compatibility report between 1.10.4 and 1.10.3](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for details.
 
 <h2 id="3versus2">Release 1.10.3 versus 1.10.2</h2>
 
@@ -238,35 +238,35 @@ H5Oget\_INFO1
 
 H5Oget\_INFO2
 
-The function H5Oget\_INFO was moved to [H5Oget\_info1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaf3751684a6706e3ba49b863406011f80), and the macro H5Oget\_INFO was created that can be mapped to either H5Oget\_INFO1 or H5Oget\_INFO2. For HDF5-1.10 and earlier releases, H5Oget\_INFO is mapped to H5Oget\_INFO1 by default.
+The function H5Oget\_INFO was moved to [H5Oget\_info1](/documentation/hdf5/latest/group___h5_o.html#gaf3751684a6706e3ba49b863406011f80), and the macro H5Oget\_INFO was created that can be mapped to either H5Oget\_INFO1 or H5Oget\_INFO2. For HDF5-1.10 and earlier releases, H5Oget\_INFO is mapped to H5Oget\_INFO1 by default.
 H5Oget\_info_by_idx
 
 H5Oget\_info_by_idx1
 
 H5Oget\_info_by_idx2
 
-The function H5Oget\_info_by_idx was moved to [H5Oget\_info_by_idx1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga7208d2cf198dcfc875603323841bffae), and the macro H5Oget\_info_by_idx was created that can be mapped to either H5Oget\_info_by_idx1 or H5Oget\_info_by_idx2. For HDF5-1.10 and earlier releases, H5Oget\_info_by_idx is mapped to H5Oget\_info_by_idx1 by default.
+The function H5Oget\_info_by_idx was moved to [H5Oget\_info_by_idx1](/documentation/hdf5/latest/group___h5_o.html#ga7208d2cf198dcfc875603323841bffae), and the macro H5Oget\_info_by_idx was created that can be mapped to either H5Oget\_info_by_idx1 or H5Oget\_info_by_idx2. For HDF5-1.10 and earlier releases, H5Oget\_info_by_idx is mapped to H5Oget\_info_by_idx1 by default.
 H5Oget\_info_by_name
 
 H5Oget\_info_by_name1
 
 H5Oget\_info_by_name2
 
-The function H5Oget\_info_by_name was moved to [H5Oget\_info_by_name1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga96ce408ffda805210844246904da2842), and the macro H5Oget\_info_by_name was created that can be mapped to either H5Oget\_info_by_name1 or H5Oget\_info_by_name2. For HDF5-1.10 and earlier releases, H5Oget\_info_by_name is mapped to H5Oget\_info_by_name1 by default.
+The function H5Oget\_info_by_name was moved to [H5Oget\_info_by_name1](/documentation/hdf5/latest/group___h5_o.html#ga96ce408ffda805210844246904da2842), and the macro H5Oget\_info_by_name was created that can be mapped to either H5Oget\_info_by_name1 or H5Oget\_info_by_name2. For HDF5-1.10 and earlier releases, H5Oget\_info_by_name is mapped to H5Oget\_info_by_name1 by default.
 H5Ovisit
 
 H5Ovisit1
 
 H5Ovisit2
 
-The function H5Ovisit was moved to [H5Ovisit1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga6efdb2a0a9fe9fe46695cc0f7bd993e7), and the macro H5Ovisit was created that can be mapped to either H5Ovisit1 or H5Ovisit2. For HDF5-1.10 and earlier releases, H5Ovisit is mapped to H5Ovisit1 by default.
+The function H5Ovisit was moved to [H5Ovisit1](/documentation/hdf5/latest/group___h5_o.html#ga6efdb2a0a9fe9fe46695cc0f7bd993e7), and the macro H5Ovisit was created that can be mapped to either H5Ovisit1 or H5Ovisit2. For HDF5-1.10 and earlier releases, H5Ovisit is mapped to H5Ovisit1 by default.
 H5Ovisit_by_name
 
 H5Ovisit_by_name1
 
 H5Ovisit_by_name2
 
-The function [H5Ovisit_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c) was moved to [H5Ovisit_by_name1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaffacf3bd66f4fe074099eae1c80914f2), and the macro H5Ovisit_by_name was created that can be mapped to either H5Ovisit_by_name1 or H5Ovisit_by_name2. For HDF5-1.10 and earlier releases, H5Ovisit_by_name is mapped to H5Ovisit_by_name1 by default.
+The function [H5Ovisit_by_name](/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c) was moved to [H5Ovisit_by_name1](/documentation/hdf5/latest/group___h5_o.html#gaffacf3bd66f4fe074099eae1c80914f2), and the macro H5Ovisit_by_name was created that can be mapped to either H5Ovisit_by_name1 or H5Ovisit_by_name2. For HDF5-1.10 and earlier releases, H5Ovisit_by_name is mapped to H5Ovisit_by_name1 by default.
  
 
 In the C High Level Interface
@@ -284,7 +284,7 @@ In the C++ API
 Several C++ wrappers were added or modified to provide additional support. See the API Compatibility Report for details.
 
 ### Compatibility Notes and Report
-See the [API compatibility report between 1.10.4 and 1.10.3]() for details.
+See the [API compatibility report between 1.10.4 and 1.10.3](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for details.
 
 <h2 id="2versus1">Release 1.10.2 versus 1.10.1</h2>
 
@@ -299,7 +299,7 @@ The following are new C functions in this release:
 | ----------------- | ------------------------------------------------------------ |
 | H5Dget\_chunk\_storage\_size]() | Returns storage amount allocated within a file for a raw data chunk in a dataset |
 | H5Fget\_eoa]() | Retrieves the file's EOA |
-| H5Fincrement\_filesize](documentation/doxygen/group___h5_f.html#gadbe82c1f6e16c21062fabd20b0ffccd4) | Sets the file's EOA to the maximum of (EOA, EOF) + increment |
+| H5Fincrement\_filesize](/documentation/hdf5/latest/group___h5_f.html#gadbe82c1f6e16c21062fabd20b0ffccd4) | Sets the file's EOA to the maximum of (EOA, EOF) + increment |
 
 | H5Fset\_libver\_bounds]() | Enables the switch of version bounds setting for a file |
 | H5FDdriver\_query]() | Queries a VFL driver for its feature flags when a file is not available (not documented in Reference Manual) |
@@ -387,7 +387,7 @@ A new option was added to h5diff:
 
 ### Compatibility Notes and Report
 
-See the [API compatibility report between 1.10.4 and 1.10.3]() for details.
+See the [API compatibility report between 1.10.4 and 1.10.3](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for details.
 
 <h2 id="1versus0">Release 1.10.1 versus 1.10.0</h2>
 
@@ -412,11 +412,11 @@ Metadata Cache Image:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Pget\_mdc\_image\_config](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga3012f7f3310c7d25ada7617896bef1ee)
+| [H5Pget\_mdc\_image\_config](/documentation/hdf5/latest/group___f_a_p_l.html#ga3012f7f3310c7d25ada7617896bef1ee)
 | Retrieves the metadata cache image configuration values for a file access property list. |
-| [H5Pset\_mdc\_image\_config](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaf234199ad4cf9c708f45893f7f9cd4d3)
+| [H5Pset\_mdc\_image\_config](/documentation/hdf5/latest/group___f_a_p_l.html#gaf234199ad4cf9c708f45893f7f9cd4d3)
 | Sets the metadata cache image option for a file access property list. |
-| [H5Fget\_mdc\_image\_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___m_d_c.html#ga7b37da15ff80c4aa5c275649f1f45b0a)
+| [H5Fget\_mdc\_image\_info](/documentation/hdf5/latest/group___m_d_c.html#ga7b37da15ff80c4aa5c275649f1f45b0a)
 | Gets information about a metadata cache image if it exists. |
 
 Metadata Cache Evict on Close:
@@ -424,35 +424,35 @@ Metadata Cache Evict on Close:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Pget\_evict\_on\_close](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga12789fcfeaea073c13202e6401f404a6)
+| [H5Pget\_evict\_on\_close](/documentation/hdf5/latest/group___f_a_p_l.html#ga12789fcfeaea073c13202e6401f404a6)
 | Retrieves the property list setting that determines whether an HDF5 object will be evicted from the library's metadata cache when it is closed. | 
-| [H5Pset\_evict\_on\_close](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaa44cc0e592608e12082dad9305b3c74d)
+| [H5Pset\_evict\_on\_close](/documentation/hdf5/latest/group___f_a_p_l.html#gaa44cc0e592608e12082dad9305b3c74d)
 | Controls the library's behavior of evicting metadata associated with a closed object. | 
 
 Paged Aggregation:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Pget\_file\_space\_page\_size](documentation/doxygen/group___f_c_p_l.html#gaab5e8c08e4f588e0af1d937fcebfc885) |
+| [H5Pget\_file\_space\_page\_size](/documentation/hdf5/latest/group___f_c_p_l.html#gaab5e8c08e4f588e0af1d937fcebfc885) |
 | Retrieves the file space page size for a file creation property list. |
-| [H5Pset\_file\_space\_page\_size](documentation/doxygen/group___f_c_p_l.html#gad012d7f3c2f1e1999eb1770aae3a4963) |
+| [H5Pset\_file\_space\_page\_size](/documentation/hdf5/latest/group___f_c_p_l.html#gad012d7f3c2f1e1999eb1770aae3a4963) |
 | Sets the file space page size (used with paged aggregation) for a file creation property list. |
-| [H5Pget\_file\_space\_strategy](documentation/doxygen/group___f_c_p_l.html#ga54cf6ca4f897ba9ee3695a15fe8e6029) |
+| [H5Pget\_file\_space\_strategy](/documentation/hdf5/latest/group___f_c_p_l.html#ga54cf6ca4f897ba9ee3695a15fe8e6029) |
 | Retrieves the file space handling strategy for a file creation property list. |
-| [H5Pset\_file\_space\_strategy](documentation/doxygen/group___f_c_p_l.html#ga167ff65f392ca3b7f1933b1cee1b9f70) |
+| [H5Pset\_file\_space\_strategy](/documentation/hdf5/latest/group___f_c_p_l.html#ga167ff65f392ca3b7f1933b1cee1b9f70) |
 | Sets the file space allocation strategy for a file creation property list. |
 
 Page Buffering:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5Pget\_page\_buffer\_size](documentation/doxygen/group___f_a_p_l.html#ga0da11baf31cf424d053aa7952c933d98) |
+| [H5Pget\_page\_buffer\_size](/documentation/hdf5/latest/group___f_a_p_l.html#ga0da11baf31cf424d053aa7952c933d98) |
 | Retrieves the maximum size for the page buffer and the minimum percentage for metadata and raw data pages. |
-| [H5Pset\_page\_buffer\_size](documentation/doxygen/group___f_a_p_l.html#ga8008cddafa81bd1ddada23f6d9a161ca) |
+| [H5Pset\_page\_buffer\_size](/documentation/hdf5/latest/group___f_a_p_l.html#ga8008cddafa81bd1ddada23f6d9a161ca) |
 | Sets the maximum size for the page buffer and the minimum percentage for metadata and raw data pages. |
-| [H5Fget\_page\_buffering\_stats](documentation/doxygen/group___h5_f.html#ga0663defe0143631f4292267c21e94202) |
+| [H5Fget\_page\_buffering\_stats](/documentation/hdf5/latest/group___h5_f.html#ga0663defe0143631f4292267c21e94202) |
 | Retrieves statistics about page access when it is enabled. |
-| [H5Freset\_page\_buffering\_stats](documentation/doxygen/group___h5_f.html#ga7ef1c0aab9a7a9112a8d0a788ec8696c) |
+| [H5Freset\_page\_buffering\_stats](/documentation/hdf5/latest/group___h5_f.html#ga7ef1c0aab9a7a9112a8d0a788ec8696c) |
 | Resets the page buffer statistics. |
 
 New and Changed Functions, Classes, Subroutines, Wrappers, and Macros
@@ -462,19 +462,19 @@ The following new C functions were added:
 
 | Function              | Description                                                  |
 | --------------------- | ------------------------------------------------------------ |
-| [H5PLappend](documentation/doxygen/group___h5_p_l.html#gac74200fdc02f794f3fae753fe8b850b0) |
+| [H5PLappend](/documentation/hdf5/latest/group___h5_p_l.html#gac74200fdc02f794f3fae753fe8b850b0) |
 | funcdesc |
-| [H5PLget](documentation/doxygen/group___h5_p_l.html#ga64a3c5450d91455624ecba582553d905) |
+| [H5PLget](/documentation/hdf5/latest/group___h5_p_l.html#ga64a3c5450d91455624ecba582553d905) |
 | funcdesc |
-| [H5PLinsert](documentation/doxygen/group___h5_p_l.html#gacc5153b0db6b3f876c3980bf34f931fc) |
+| [H5PLinsert](/documentation/hdf5/latest/group___h5_p_l.html#gacc5153b0db6b3f876c3980bf34f931fc) |
 | funcdesc |
-| [H5PLprepend](documentation/doxygen/group___h5_p_l.html#ga1f2300ef2de6e430af330de7d194576f) |
+| [H5PLprepend](/documentation/hdf5/latest/group___h5_p_l.html#ga1f2300ef2de6e430af330de7d194576f) |
 | funcdesc |
-| [H5PLremove](documentation/doxygen/group___h5_p_l.html#gaa566196b7c6970c255feac4cf9f3bf40) |
+| [H5PLremove](/documentation/hdf5/latest/group___h5_p_l.html#gaa566196b7c6970c255feac4cf9f3bf40) |
 | funcdesc |
-| [H5PLreplace](documentation/doxygen/group___h5_p_l.html#gab0f8d4e8d0b81cb55cf8b9de5095dc0b) |
+| [H5PLreplace](/documentation/hdf5/latest/group___h5_p_l.html#gab0f8d4e8d0b81cb55cf8b9de5095dc0b) |
 | funcdesc |
-| [H5PLsize](documentation/doxygen/group___h5_p_l.html#ga30b799ad7e9645312ef8975a610b4b18) |
+| [H5PLsize](/documentation/hdf5/latest/group___h5_p_l.html#ga30b799ad7e9645312ef8975a610b4b18) |
 | funcdesc | 
 
 #### In the C++ API
@@ -504,7 +504,7 @@ PLEASE review the Compatibility report below for complete information on the C++
 
 ### Compatibility Report
 
-See the [API compatibility report between 1.10.1 and 1.10.0-patch1]() for details.
+See the [API compatibility report between 1.10.1 and 1.10.0-patch1](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/hdf5-1.10.6-interface_compatibility_report.html) for details.
 
 <h2 id="0versus8_16">Release 1.10.0 versus Release 1.8.16</h2>
 
@@ -555,19 +555,19 @@ Appends data to a dataset along a specified dimension.
 
 | Function          | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |
-| [H5Pget\_append\_flush](documentation/doxygen/group___d_a_p_l.html#gacd6803640eebd20e408c330192b09fa6) |
+| [H5Pget\_append\_flush](/documentation/hdf5/latest/group___d_a_p_l.html#gacd6803640eebd20e408c330192b09fa6) |
 | Retrieves the values of the append property that is set up in the dataset access property list. |
-| [H5Pset\_append\_flush](documentation/doxygen/group___d_a_p_l.html#ga2f685a7b3f3a4fa35ddcd1659ab4a835) |
+| [H5Pset\_append\_flush](/documentation/hdf5/latest/group___d_a_p_l.html#ga2f685a7b3f3a4fa35ddcd1659ab4a835) |
 | Sets two actions to perform when the size of a dataset's dimension being appended reaches a specified boundary. |
-| [H5Pget\_object\_flush\_cb](documentation/doxygen/group___f_a_p_l.html#gadb66d434fd8d2f600213b0eec539564e) |
+| [H5Pget\_object\_flush\_cb](/documentation/hdf5/latest/group___f_a_p_l.html#gadb66d434fd8d2f600213b0eec539564e) |
 | Retrieves the object flush property values from the file access property list. |
-| [H5Pset\_object\_flush\_cb](documentation/doxygen/group___f_a_p_l.html#gab4a4a788af5b6e88381dda0df2efbf19) |
+| [H5Pset\_object\_flush\_cb](/documentation/hdf5/latest/group___f_a_p_l.html#gab4a4a788af5b6e88381dda0df2efbf19) |
 | Sets a callback function to invoke when an object flush occurs in the file. |
-| [H5Odisable\_mdc\_flushes](documentation/doxygen/group___h5_o.html#ga0908be309da1fb4f771c1e264fac22ae) |
+| [H5Odisable\_mdc\_flushes](/documentation/hdf5/latest/group___h5_o.html#ga0908be309da1fb4f771c1e264fac22ae) |
 | Prevents metadata entries for an HDF5 object from being flushed from the metadata cache to storage. |
-| [H5Oenable\_mdc\_flushes](documentation/doxygen/group___h5_o.html#ga21014920bdabf6973e233796d7174156) |
+| [H5Oenable\_mdc\_flushes](/documentation/hdf5/latest/group___h5_o.html#ga21014920bdabf6973e233796d7174156) |
 | Returns the cache entries associated with an HDF5 object to the default metadata flush and eviction algorithm. |
-| [H5Oare\_mdc\_flushes\_disabled](documentation/doxygen/group___h5_o.html#gab2fa388aadd1ff154ee150cbb4884c1c) |
+| [H5Oare\_mdc\_flushes\_disabled](/documentation/hdf5/latest/group___h5_o.html#gab2fa388aadd1ff154ee150cbb4884c1c) |
 | Determines if an HDF5 object (dataset, group, committed datatype) has had flushes of metadata entries disabled. |
  
 Command-line Tools:
@@ -701,11 +701,11 @@ The following new functions appear in HDF5 Release 1.10.0 but are not yet docume
  
 | Function          | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |
-| [H5FDlock](documentation/doxygen/_h5_f_ddevelop_8h.html#a8d1d98a681375a4203bfd74b70b3aadd) | Sets a file lock |
-| [H5FDunlock](documentation/doxygen/_h5_f_ddevelop_8h.html#aebafd003d12e6ec7b56548ce5c169b9d) | Removes a file lock |
-| [H5LDget\_dset\_dims](documentation/doxygen/group___h5_l_t.html#gae8ced4c8df9742761546410c214d8c3b) | Retrieves the current dimension sizes of a dataset |
-| [H5LDget\_dset\_elmts](documentation/doxygen/group___h5_l_t.html#ga4a42f8b0c4d2007906361541d0d6bfdf) | Retrieves selected data from the dataset |
-| [H5LDget\_dset\_type_size](documentation/doxygen/group___h5_l_t.html#gabb424859982bf8953b138372fbf7ba7f) | Returns the size in bytes of the dataset's datatype |
+| [H5FDlock](/documentation/hdf5/latest/_h5_f_ddevelop_8h.html#a8d1d98a681375a4203bfd74b70b3aadd) | Sets a file lock |
+| [H5FDunlock](/documentation/hdf5/latest/_h5_f_ddevelop_8h.html#aebafd003d12e6ec7b56548ce5c169b9d) | Removes a file lock |
+| [H5LDget\_dset\_dims](/documentation/hdf5/latest/group___h5_l_t.html#gae8ced4c8df9742761546410c214d8c3b) | Retrieves the current dimension sizes of a dataset |
+| [H5LDget\_dset\_elmts](/documentation/hdf5/latest/group___h5_l_t.html#ga4a42f8b0c4d2007906361541d0d6bfdf) | Retrieves selected data from the dataset |
+| [H5LDget\_dset\_type_size](/documentation/hdf5/latest/group___h5_l_t.html#gabb424859982bf8953b138372fbf7ba7f) | Returns the size in bytes of the dataset's datatype |
 
 
 New and Changed Elements of the Packet Table (H5PT) High-level API
@@ -812,7 +812,7 @@ H5Lexists
 The behavior of this function has changed in this release. When testing the pathname / (a slash representing the root of an HDF5 file) H5Lexists now returns successfully with the value 1 (one). See the entry in the HDF5 Reference Manual for H5Lexists for more information.
 
 API Compatibility
-See API Compatibility Macros in HDF5 for details on the following.
+See [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 for details on the following.
 
 New API Compatibility Flag
 
@@ -861,7 +861,7 @@ RELEASE.txt can be found in the release\_docs/ subdirectory at the root level of
 
 ### Compatibility Report and Comments
 
-[Compatibility report for Release 1.10.0 versus Release 1.8.16]()
+[Compatibility report for Release 1.10.0 versus Release 1.8.16](https://htmlpreview.github.io/?https://github.com/HDFGroup/hdf5doc/blob/master/html/ADGuide/Compatibility_Report/CR_1.10.0.html)
 
 Comments regarding the report
 

--- a/documentation/hdf5-docs/release_specifics/sw_changes_1.12.md
+++ b/documentation/hdf5-docs/release_specifics/sw_changes_1.12.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Software Changes from Release to Release in HDF5 1.12
 
-For a description of the major new features that were introduced, please see [New Features in HDF5 Release 1.12](sw_changes_1.12.md).
+For a description of the major new features that were introduced, please see [New Features in HDF5 Release 1.12](sw_changes_1.12.html).
 
 This page provides information on the changes that a maintenance developer needs to be aware of between successive releases of HDF5, such as:
 
@@ -44,10 +44,10 @@ The following are new C functions in this release:
 
 | Function                             | Description                                  |
 | ------------------------------------ | -------------------------------------------- |
-| [H5DSwith_new_ref](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_d_s.html#gaed2b97139202dfe69f3f2a7364c10fbc)         | Determines if new references are used with dimension scales
-| [H5LTget_attribute_ullong](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l_t.html#ga366fbd6822449e762109c012cf2b6f08) | Reads an unsigned long long attribute
-| [H5LTset_attribute_ullong](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l_t.html#ga004f5266cea7ce5f6a77ee41b05faa8b) | Create an unsigned long long attribute
-| [H5VLobject_is_native](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gad7fa2adf3bb8a834169ef2fa50c76827)     | Determines whether an object ID represents a native VOL connector object
+| [H5DSwith_new_ref](/documentation/hdf5/latest/group___h5_d_s.html#gaed2b97139202dfe69f3f2a7364c10fbc)         | Determines if new references are used with dimension scales
+| [H5LTget_attribute_ullong](/documentation/hdf5/latest/group___h5_l_t.html#ga366fbd6822449e762109c012cf2b6f08) | Reads an unsigned long long attribute
+| [H5LTset_attribute_ullong](/documentation/hdf5/latest/group___h5_l_t.html#ga004f5266cea7ce5f6a77ee41b05faa8b) | Create an unsigned long long attribute
+| [H5VLobject_is_native](/documentation/hdf5/latest/group___h5_v_l.html#gad7fa2adf3bb8a834169ef2fa50c76827)     | Determines whether an object ID represents a native VOL connector object
 
 See API Compatibility Reports for 1.12.2 for complete details.
 
@@ -59,13 +59,13 @@ The following are new C functions in this release:
 
 | Function                             | Description                                  |
 | ------------------------------------ | -------------------------------------------- |
-| [H5Pget_fapl_splitter](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list
-| [H5Pset_fapl_splitter](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga49f386ea235bb48128e54c962c499f07) | Sets the file access property list to use the splitter driver
-| [H5Pget_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) | Gets the file locking property values
-| [H5Pset_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) | Sets the file locking property values
-| [H5get_free_list_sizes](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5.html#ga2310d963a6f48ec12fda8c0c8bbefbbb) | Gets the current size of the free lists used to manage memory
-| [H5Ssel_iter_reset](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga411bbc06a31814bff9f476712c2a791c) | Resets a dataspace selection iterator back to an initial state
-| [H5VLquery_optional](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga17ef00e528d99eda5879d749c2a12043) | Determines whether a VOL connector supports a particular optional callback operation
+| [H5Pget_fapl_splitter](/documentation/hdf5/latest/group___f_a_p_l.html#gaf6ac1c131acee33dfb878593dfefb4ac) | Retrieves information for a splitter file access property list
+| [H5Pset_fapl_splitter](/documentation/hdf5/latest/group___f_a_p_l.html#ga49f386ea235bb48128e54c962c499f07) | Sets the file access property list to use the splitter driver
+| [H5Pget_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) | Gets the file locking property values
+| [H5Pset_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) | Sets the file locking property values
+| [H5get_free_list_sizes](/documentation/hdf5/latest/group___h5.html#ga2310d963a6f48ec12fda8c0c8bbefbbb) | Gets the current size of the free lists used to manage memory
+| [H5Ssel_iter_reset](/documentation/hdf5/latest/group___h5_s.html#ga411bbc06a31814bff9f476712c2a791c) | Resets a dataspace selection iterator back to an initial state
+| [H5VLquery_optional](/documentation/hdf5/latest/group___h5_v_l.html#ga17ef00e528d99eda5879d749c2a12043) | Determines whether a VOL connector supports a particular optional callback operation
  
 
 In the C++ Wrapper
@@ -74,9 +74,9 @@ The following C++ wrappers were added:
 
 | Function                             | Description                                  |
 | ------------------------------------ | -------------------------------------------- |
-| [DataSet::operator=](https://support.hdfgroup.org/documentation/doxygen/class_h5_1_1_data_set.html#a919a8f99c6b8e1f598065916c75f6d60) | Operator= for [DataSet](https://support.hdfgroup.org/documentation/doxygen/class_h5_1_1_data_set.html) class
-| [FileAccPropList::getFileLocking](documentation/doxygen/class_h5_1_1_file_acc_prop_list.html#ad49d44890148a0d6cd68e1e6a9c8eb7e) | See [H5Pget_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) for details
-| [FileAccPropList::setFileLocking](documentation/doxygen/class_h5_1_1_file_acc_prop_list.html#adee337bf57e974169a5ac87be358e00d) | See [H5Pset_file_locking](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) for details
+| [DataSet::operator=](/documentation/hdf5/latest/class_h5_1_1_data_set.html#a919a8f99c6b8e1f598065916c75f6d60) | Operator= for [DataSet](/documentation/hdf5/latest/class_h5_1_1_data_set.html) class
+| [FileAccPropList::getFileLocking](/documentation/hdf5/latest/class_h5_1_1_file_acc_prop_list.html#ad49d44890148a0d6cd68e1e6a9c8eb7e) | See [H5Pget_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga5de19a5a8ac23ca417aa2d49d708dc2d) for details
+| [FileAccPropList::setFileLocking](/documentation/hdf5/latest/class_h5_1_1_file_acc_prop_list.html#adee337bf57e974169a5ac87be358e00d) | See [H5Pset_file_locking](/documentation/hdf5/latest/group___f_a_p_l.html#ga503e9ff6121a67cf53f8b67054ed9391) for details
 
 See the API Compatibility report for complete details.
 
@@ -88,7 +88,7 @@ See API Compatibility Reports for 1.12 for information regarding compatibility w
 This section lists interface-level changes and other user-visible changes in behavior in the transition from HDF5 Release 1.10.6 to Release 1.12.0.
 
 ### New Features
-For a description of the major new features that were introduced, please see [New Features in HDF5 Release 1.12](new_features_1_12.md).
+For a description of the major new features that were introduced, please see [New Features in HDF5 Release 1.12](new_features_1_12.html).
 
 ### New and Changed Functions, Classes, Subroutines, Wrappers, and Macros
 
@@ -98,85 +98,85 @@ Following are the new or changed APIs introduced in HDF5-1.12.0. Those introduce
 
 | Function              | Fortran      | Description                                  |
 | ----------------------|------------- | -------------------------------------------- |
-| [H5Fdelete](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#ga2e8b5e19b343123e8ab21442f9169a62) | N | Deletes an HDF5 file |
-| [H5Fget_fileno](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#ga402205688af065ab5db0fe20417d5484) | Y | Retrieves a file's file number that uniquely identifies the open file |
-| [H5Fis_accessible](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_f.html#ga584471c3b98453b9b04a4bf9af847442) | Y | Determines if a file can be opened with a given fapl |
+| [H5Fdelete](/documentation/hdf5/latest/group___h5_f.html#ga2e8b5e19b343123e8ab21442f9169a62) | N | Deletes an HDF5 file |
+| [H5Fget_fileno](/documentation/hdf5/latest/group___h5_f.html#ga402205688af065ab5db0fe20417d5484) | Y | Retrieves a file's file number that uniquely identifies the open file |
+| [H5Fis_accessible](/documentation/hdf5/latest/group___h5_f.html#ga584471c3b98453b9b04a4bf9af847442) | Y | Determines if a file can be opened with a given fapl |
 |  | | |
-| [H5Iiterate](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_i_u_d.html#ga3bc2a11a594bf484cc5dc69ac987d0f4) | N | Calls a callback for each member of the identifier type specified |
+| [H5Iiterate](/documentation/hdf5/latest/group___h5_i_u_d.html#ga3bc2a11a594bf484cc5dc69ac987d0f4) | N | Calls a callback for each member of the identifier type specified |
 |  | | |
-| [H5Lget_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l.html#ga97279697f3010a6ad31dd7f4341eb698)<br>[H5Lget_info1](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#gacc2ad7f2b402c4bf9bb122d7f43b98dc)<br>[H5Lget_info2](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#ga65e63c6e880fd0183c40486d6748e400) | Y (no change) | The function H5L_GET_INFO was moved to H5L_GET_INFO1, and H5L_GET_INFO2 was introduced. The macro H5L_GET_INFO was created that can be mapped to either H5L_GET_INFO1 or H5L_GET_INFO2. For HDF5-1.12, H5L_GET_INFO is mapped to H5L_GET_INFO2 by default.  In earlier releases, H5L_GET_INFO is mapped to H5L_GET_INFO1. |
+| [H5Lget_info](/documentation/hdf5/latest/group___h5_l.html#ga97279697f3010a6ad31dd7f4341eb698)<br>[H5Lget_info1](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#gacc2ad7f2b402c4bf9bb122d7f43b98dc)<br>[H5Lget_info2](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#ga65e63c6e880fd0183c40486d6748e400) | Y (no change) | The function H5L_GET_INFO was moved to H5L_GET_INFO1, and H5L_GET_INFO2 was introduced. The macro H5L_GET_INFO was created that can be mapped to either H5L_GET_INFO1 or H5L_GET_INFO2. For HDF5-1.12, H5L_GET_INFO is mapped to H5L_GET_INFO2 by default.  In earlier releases, H5L_GET_INFO is mapped to H5L_GET_INFO1. |
 |  | | |
-| [H5Lget_info_by_idx](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_l.html#ga4db00b8b944eae68233438165c784b67)<br>[H5Lget_info_by_idx1](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#ga7ed207f47e0e0f768f0d540c73e37e2a)<br>[H5Lget_info_by_idx2](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#gaecfb3ef8520e9224b24a151ff8459ba9) | Y (no change) | The function H5L_GET_INFO_BY_IDX was moved to H5L_GET_INFO_BY_IDX1, and H5L_GET_INFO_BY_IDX2 was introduced. The macro H5L_GET_INFO_BY_IDX was created that can be mapped to either H5L_GET_INFO_BY_IDX1 or H5L_GET_INFO_BY_IDX2. For HDF5-1.12, H5L_GET_INFO_BY_IDX is mapped to H5L_GET_INFO_BY_IDX2 by default.  In earlier releases, H5L_GET_INFO_BY_IDX is mapped to H5L_GET_INFO_BY_IDX1. |
-| [H5Literate](https://support.hdfgroup.org/documentation/hdf5/latest/group___t_r_a_v.html#ga55406698106930db68242987c11ba051)<br>[H5Literate1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga1e7c0a8cf17699563c02e128f27042f1)<br>[H5Literate2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gad7ca4206f06b5ada85b6ec5867ec6c73) | Y (no change) | The function H5L_ITERATE was moved to H5L_ITERATE1, and H5L_ITERATE2 was introduced. The macro H5L_ITERATE was created that can be mapped to either H5L_ITERATE1 or H5L_ITERATE2. For HDF5-1.12, H5L_ITERATE is mapped to H5L_ITERATE2 by default.  In earlier releases, H5L_ITERATE is mapped to H5L_ITERATE1. |
-| [H5Literate_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___t_r_a_v.html#ga655b002428e0176c2fa23a0315fbbcc2)<br>[H5Literate_by_name1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga87e036da0c8d1146a073f3ee08e0fedc)<br>[H5Literate_by_name2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga745a65eb516ce40a3be43490aaeb5c5e) | Y (no change) | The function H5L_ITERATE_BY_NAME was moved to H5L_ITERATE_BY_NAME1, and H5L_ITERATE_BY_NAME2 was introduced. The macro H5L_ITERATE_BY_NAME was created that can be mapped to either H5L_ITERATE_BY_NAME1 or H5L_ITERATE_BY_NAME2. For HDF5-1.12, H5L_ITERATE_BY_NAME is mapped to H5L_ITERATE_BY_NAME2 by default.  In earlier releases, H5L_ITERATE_BY_NAME is mapped to H5L_ITERATE_BY_NAME1. |
-| [H5Lvisit](https://support.hdfgroup.org/documentation/hdf5/latest/group___t_r_a_v.html#gac0558936502924d9e898d8b6e041ed69)<br>[H5Lvisit1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga5424ef7043c82147490d027a0e8a59ef)<br>[H5Lvisit2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gae1c6f963892a5f4e8922a66fbe338f66) | N | The function H5L_VISIT was moved to H5L_VISIT1, and H5L_VISIT2 was introduced. The macro H5L_VISIT was created that can be mapped to either H5L_VISIT1 or H5L_VISIT2. For HDF5-1.12, H5L_VISIT is mapped to H5L_VISIT2 by default.  In earlier releases, H5L_VISIT is mapped to H5L_VISIT1. |
-| [H5Lvisit_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___t_r_a_v.html#ga138405315e233673741893e4e250f055)<br>[H5Lvisit_by_name1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga1f1ba1bb4d44f2c111990024809417ac)<br>[H5Lvisit_by_name2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gafee93792c7e27a7e78b1ec221876b173) | N | The function H5L_VISIT_BY_NAME was moved to H5L_VISIT_BY_NAME1, and H5L_VISIT_BY_NAME2 was introduced. The macro H5L_VISIT_BY_NAME was created that can be mapped to either H5L_VISIT_BY_NAME1 or H5L_VISIT_BY_NAME2. For HDF5-1.12, H5L_VISIT_BY_NAME is mapped to H5L_VISIT_BY_NAME2 by default.  In earlier releases, H5L_VISIT_BY_NAME is mapped to H5L_VISIT_BY_NAME1. |
+| [H5Lget_info_by_idx](/documentation/hdf5/latest/group___h5_l.html#ga4db00b8b944eae68233438165c784b67)<br>[H5Lget_info_by_idx1](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#ga7ed207f47e0e0f768f0d540c73e37e2a)<br>[H5Lget_info_by_idx2](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_l.html#gaecfb3ef8520e9224b24a151ff8459ba9) | Y (no change) | The function H5L_GET_INFO_BY_IDX was moved to H5L_GET_INFO_BY_IDX1, and H5L_GET_INFO_BY_IDX2 was introduced. The macro H5L_GET_INFO_BY_IDX was created that can be mapped to either H5L_GET_INFO_BY_IDX1 or H5L_GET_INFO_BY_IDX2. For HDF5-1.12, H5L_GET_INFO_BY_IDX is mapped to H5L_GET_INFO_BY_IDX2 by default.  In earlier releases, H5L_GET_INFO_BY_IDX is mapped to H5L_GET_INFO_BY_IDX1. |
+| [H5Literate](/documentation/hdf5/latest/group___t_r_a_v.html#ga55406698106930db68242987c11ba051)<br>[H5Literate1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga1e7c0a8cf17699563c02e128f27042f1)<br>[H5Literate2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gad7ca4206f06b5ada85b6ec5867ec6c73) | Y (no change) | The function H5L_ITERATE was moved to H5L_ITERATE1, and H5L_ITERATE2 was introduced. The macro H5L_ITERATE was created that can be mapped to either H5L_ITERATE1 or H5L_ITERATE2. For HDF5-1.12, H5L_ITERATE is mapped to H5L_ITERATE2 by default.  In earlier releases, H5L_ITERATE is mapped to H5L_ITERATE1. |
+| [H5Literate_by_name](/documentation/hdf5/latest/group___t_r_a_v.html#ga655b002428e0176c2fa23a0315fbbcc2)<br>[H5Literate_by_name1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga87e036da0c8d1146a073f3ee08e0fedc)<br>[H5Literate_by_name2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga745a65eb516ce40a3be43490aaeb5c5e) | Y (no change) | The function H5L_ITERATE_BY_NAME was moved to H5L_ITERATE_BY_NAME1, and H5L_ITERATE_BY_NAME2 was introduced. The macro H5L_ITERATE_BY_NAME was created that can be mapped to either H5L_ITERATE_BY_NAME1 or H5L_ITERATE_BY_NAME2. For HDF5-1.12, H5L_ITERATE_BY_NAME is mapped to H5L_ITERATE_BY_NAME2 by default.  In earlier releases, H5L_ITERATE_BY_NAME is mapped to H5L_ITERATE_BY_NAME1. |
+| [H5Lvisit](/documentation/hdf5/latest/group___t_r_a_v.html#gac0558936502924d9e898d8b6e041ed69)<br>[H5Lvisit1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga5424ef7043c82147490d027a0e8a59ef)<br>[H5Lvisit2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gae1c6f963892a5f4e8922a66fbe338f66) | N | The function H5L_VISIT was moved to H5L_VISIT1, and H5L_VISIT2 was introduced. The macro H5L_VISIT was created that can be mapped to either H5L_VISIT1 or H5L_VISIT2. For HDF5-1.12, H5L_VISIT is mapped to H5L_VISIT2 by default.  In earlier releases, H5L_VISIT is mapped to H5L_VISIT1. |
+| [H5Lvisit_by_name](/documentation/hdf5/latest/group___t_r_a_v.html#ga138405315e233673741893e4e250f055)<br>[H5Lvisit_by_name1](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#ga1f1ba1bb4d44f2c111990024809417ac)<br>[H5Lvisit_by_name2](https://docs.hdfgroup.org/hdf5/v1_14/group___t_r_a_v.html#gafee93792c7e27a7e78b1ec221876b173) | N | The function H5L_VISIT_BY_NAME was moved to H5L_VISIT_BY_NAME1, and H5L_VISIT_BY_NAME2 was introduced. The macro H5L_VISIT_BY_NAME was created that can be mapped to either H5L_VISIT_BY_NAME1 or H5L_VISIT_BY_NAME2. For HDF5-1.12, H5L_VISIT_BY_NAME is mapped to H5L_VISIT_BY_NAME2 by default.  In earlier releases, H5L_VISIT_BY_NAME is mapped to H5L_VISIT_BY_NAME1. |
 |  |  | |
-| [H5Oget_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaf4f302a33faba9e1c2b5f64c62ca4ed5)<br>[H5Oget_info3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gaf0fbf7d780a1eefce920facadb198013) | N/A | The function H5O_GET_INFO was replaced by the macro H5O_GET_INFO and the function H5O_GET_INFO3 was added. |
-| [H5Oget_info_by_idx](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gafe764884e1530f86079288dd5895a7bd)<br>[H5Oget_info_by_idx3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gafa2f8884f7d3e7fd9b8549f5b59fd9eb) | N/A | The function H5O_GET_INFO_BY_IDX was replaced by the macro H5O_GET_INFO_BY_IDX. The function H5O_GET_INFO_BY_IDX3 was added. |
-| [H5Oget_info_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga16d8ac07f9244cfccb42b5f309ca6b3c)<br>[H5Oget_info_by_name3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gabb69c962999e027cef0079bbb1282199) | N/A | The function H5O_GET_INFO_BY_NAME was replaced by the macro H5O_GET_INFO_BY_NAME. The function H5O_GET_INFO_BY_NAME3 was added. |
-| [H5Oget_native_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga677d99ab106e2032b991b75b75de0e46) | N | Retrieves the native file format information about an object |
-| [H5Oget_native_info_by_idx](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gafa6570d8b0ef6e2aff75093e1f99f67e) | N | Retrieves native file format information about an object according to the order of an index |
-| [H5Oget_native_info_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga296ded21aeac3921fee07272353b8476) | N | Retrieves native file format information about an object given its name |
-| [H5Oopen_by_token](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga2ea3627cf171d0565307702a5e203262) | Y | Opens an object in an HDF5 file using its VOL independent token |
-| [H5Otoken_cmp](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gaeb8da4fbe62f8a3cd9146a7ac1093562) | Y | Compares two VOL connector object tokens |
-| [H5Otoken_from_str](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga5136c14b4e907f15007030d7a6d6cd24) | N | Deserializes a string into a connector object token |
-| [H5Otoken_to_str](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga2bdd7528090f7f2c4b361ab4cc7735f6) | N | Serializes a connector's object token into a string |
-| [H5Ovisit](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga5ce86255fcc34ceaf84a62551cd24233)
- [H5Ovisit3](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga6d03115ae0e5e5b516bbf35bb492266a) | N/A | The function H5O_VISIT was replaced by the macro H5O_VISIT and the function H5O_VISIT3 was added |
-| [H5Ovisit_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c)
- [H5Ovisit_by_name3](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_o.html#ga34815400b01df59c4dac19436124885a) | N/A | The function H5O_VISIT_BY_NAME was replaced by the macro H5O_VISIT_BY_NAME, and the function H5O_VISIT_BY_NAME3 was added. |
+| [H5Oget_info](/documentation/hdf5/latest/group___h5_o.html#gaf4f302a33faba9e1c2b5f64c62ca4ed5)<br>[H5Oget_info3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gaf0fbf7d780a1eefce920facadb198013) | N/A | The function H5O_GET_INFO was replaced by the macro H5O_GET_INFO and the function H5O_GET_INFO3 was added. |
+| [H5Oget_info_by_idx](/documentation/hdf5/latest/group___h5_o.html#gafe764884e1530f86079288dd5895a7bd)<br>[H5Oget_info_by_idx3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gafa2f8884f7d3e7fd9b8549f5b59fd9eb) | N/A | The function H5O_GET_INFO_BY_IDX was replaced by the macro H5O_GET_INFO_BY_IDX. The function H5O_GET_INFO_BY_IDX3 was added. |
+| [H5Oget_info_by_name](/documentation/hdf5/latest/group___h5_o.html#ga16d8ac07f9244cfccb42b5f309ca6b3c)<br>[H5Oget_info_by_name3](https://docs.hdfgroup.org/hdf5/v1_14/group___h5_o.html#gabb69c962999e027cef0079bbb1282199) | N/A | The function H5O_GET_INFO_BY_NAME was replaced by the macro H5O_GET_INFO_BY_NAME. The function H5O_GET_INFO_BY_NAME3 was added. |
+| [H5Oget_native_info](/documentation/hdf5/latest/group___h5_o.html#ga677d99ab106e2032b991b75b75de0e46) | N | Retrieves the native file format information about an object |
+| [H5Oget_native_info_by_idx](/documentation/hdf5/latest/group___h5_o.html#gafa6570d8b0ef6e2aff75093e1f99f67e) | N | Retrieves native file format information about an object according to the order of an index |
+| [H5Oget_native_info_by_name](/documentation/hdf5/latest/group___h5_o.html#ga296ded21aeac3921fee07272353b8476) | N | Retrieves native file format information about an object given its name |
+| [H5Oopen_by_token](/documentation/hdf5/latest/group___h5_o.html#ga2ea3627cf171d0565307702a5e203262) | Y | Opens an object in an HDF5 file using its VOL independent token |
+| [H5Otoken_cmp](/documentation/hdf5/latest/group___h5_o.html#gaeb8da4fbe62f8a3cd9146a7ac1093562) | Y | Compares two VOL connector object tokens |
+| [H5Otoken_from_str](/documentation/hdf5/latest/group___h5_o.html#ga5136c14b4e907f15007030d7a6d6cd24) | N | Deserializes a string into a connector object token |
+| [H5Otoken_to_str](/documentation/hdf5/latest/group___h5_o.html#ga2bdd7528090f7f2c4b361ab4cc7735f6) | N | Serializes a connector's object token into a string |
+| [H5Ovisit](/documentation/hdf5/latest/group___h5_o.html#ga5ce86255fcc34ceaf84a62551cd24233)
+ [H5Ovisit3](/documentation/hdf5/latest/group___h5_o.html#ga6d03115ae0e5e5b516bbf35bb492266a) | N/A | The function H5O_VISIT was replaced by the macro H5O_VISIT and the function H5O_VISIT3 was added |
+| [H5Ovisit_by_name](/documentation/hdf5/latest/group___h5_o.html#gab02a69e88b11404e7fd61f55344b186c)
+ [H5Ovisit_by_name3](/documentation/hdf5/latest/group___h5_o.html#ga34815400b01df59c4dac19436124885a) | N/A | The function H5O_VISIT_BY_NAME was replaced by the macro H5O_VISIT_BY_NAME, and the function H5O_VISIT_BY_NAME3 was added. |
 |  |  | |
-| [H5Pencode](https://support.hdfgroup.org/documentation/hdf5/latest/_h5version_8h.html#af1a9ff52a69251d57ffa686102f162a8)
- [H5Pencode1](https://support.hdfgroup.org/documentation/hdf5/latest/group___p_l_c_r_a.html#gaf40518cb161ee9508da4b9c0d34553bf)
- [H5Pencode2](https://support.hdfgroup.org/documentation/hdf5/latest/group___p_l_c_r.html#ga37b1b6666e62a86389015e7dfc384faa) | N | Encodes properties on a property list into a buffer<br>The previous function was renamed to H5P_ENCODE1 and deprecated, and the macro H5P_ENCODE was introduced. |
-| [H5Pget_vol_id](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga5f133bdf09ca5a32622688d1ba5cc838) | Y | Returns the identifier of the current VOL connector |
-| [H5Pget_vol_info](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gafc58db23c257cdcf2f0c1c3ae911ab0f) | N | Returns a copy of the VOL information for a connector |
-| [H5Pset_vol](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#ga8aaa97e70b2544c3d95d908e1ae5b0f0) | Y | Set the file VOL connector for a file access property list |
+| [H5Pencode](/documentation/hdf5/latest/_h5version_8h.html#af1a9ff52a69251d57ffa686102f162a8)
+ [H5Pencode1](/documentation/hdf5/latest/group___p_l_c_r_a.html#gaf40518cb161ee9508da4b9c0d34553bf)
+ [H5Pencode2](/documentation/hdf5/latest/group___p_l_c_r.html#ga37b1b6666e62a86389015e7dfc384faa) | N | Encodes properties on a property list into a buffer<br>The previous function was renamed to H5P_ENCODE1 and deprecated, and the macro H5P_ENCODE was introduced. |
+| [H5Pget_vol_id](/documentation/hdf5/latest/group___f_a_p_l.html#ga5f133bdf09ca5a32622688d1ba5cc838) | Y | Returns the identifier of the current VOL connector |
+| [H5Pget_vol_info](/documentation/hdf5/latest/group___f_a_p_l.html#gafc58db23c257cdcf2f0c1c3ae911ab0f) | N | Returns a copy of the VOL information for a connector |
+| [H5Pset_vol](/documentation/hdf5/latest/group___f_a_p_l.html#ga8aaa97e70b2544c3d95d908e1ae5b0f0) | Y | Set the file VOL connector for a file access property list |
 |  | | |
-| [H5Rcopy](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gad5b7b117cfaea90d1e4786304c58c55c) | N | Copies an existing reference |
-| [H5Rcreate_attr](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gacae1bf2263befeac54d81f27995721f8) | N | Creates an attribute reference |
-| [H5Rcreate_object](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gad0fb6ec99ecefa602756a5682addfc69) | N | Creates an object reference |
-| [H5Rcreate_region](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga60134eb917afbe89aa23eb25a30d249b) | N | Creates a region reference |
-| [H5Rdestroy](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga026114e6c23588bf89bb473eb9e4d095) | N | Closes a reference |
-| [H5Requal](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga8d7dac2c604356f2fc657f36a201aea0) | N | Determines whether two references are equal |
-| [H5Rget_attr_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gaf9c6823346cc34f02b9f5d11e56344a0) | N | Retrieves the attribute name for a referenced object |
-| [H5Rget_file_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga659d950e37122a59d50612b407a48900) | N | Retrieves the file name for a referenced object |
-| [H5Rget_obj_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gac5a0a3a874cd3c4dc630579521539bb6) | N | Retrieves the object name for a referenced object |
-| [H5Rget_obj_type3](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga6fb098a1a4c9369d76dbeeaf40d6d2af) | N | Retrieves the type of object that an object reference points to |
-| [H5Rget_type](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga56989d33835ec289269d366dc28aa4ad) | N | Retrieves the type of reference |
-| [H5Ropen_attr](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga2a00d73b9a13b9069d0ad39225dd9f71) | N | Opens the referenced HDF5 attribute |
-| [H5Ropen_object](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#gaa6692bd3a5b490c8db05b90a5888d0dd) | N | Opens the referenced HDF5 object |
-| [H5Ropen_region](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_r.html#ga400154b014acd1736bae9a127f4e9a1a) | N | Sets up a dataspace and selection as specified by a region reference |
+| [H5Rcopy](/documentation/hdf5/latest/group___h5_r.html#gad5b7b117cfaea90d1e4786304c58c55c) | N | Copies an existing reference |
+| [H5Rcreate_attr](/documentation/hdf5/latest/group___h5_r.html#gacae1bf2263befeac54d81f27995721f8) | N | Creates an attribute reference |
+| [H5Rcreate_object](/documentation/hdf5/latest/group___h5_r.html#gad0fb6ec99ecefa602756a5682addfc69) | N | Creates an object reference |
+| [H5Rcreate_region](/documentation/hdf5/latest/group___h5_r.html#ga60134eb917afbe89aa23eb25a30d249b) | N | Creates a region reference |
+| [H5Rdestroy](/documentation/hdf5/latest/group___h5_r.html#ga026114e6c23588bf89bb473eb9e4d095) | N | Closes a reference |
+| [H5Requal](/documentation/hdf5/latest/group___h5_r.html#ga8d7dac2c604356f2fc657f36a201aea0) | N | Determines whether two references are equal |
+| [H5Rget_attr_name](/documentation/hdf5/latest/group___h5_r.html#gaf9c6823346cc34f02b9f5d11e56344a0) | N | Retrieves the attribute name for a referenced object |
+| [H5Rget_file_name](/documentation/hdf5/latest/group___h5_r.html#ga659d950e37122a59d50612b407a48900) | N | Retrieves the file name for a referenced object |
+| [H5Rget_obj_name](/documentation/hdf5/latest/group___h5_r.html#gac5a0a3a874cd3c4dc630579521539bb6) | N | Retrieves the object name for a referenced object |
+| [H5Rget_obj_type3](/documentation/hdf5/latest/group___h5_r.html#ga6fb098a1a4c9369d76dbeeaf40d6d2af) | N | Retrieves the type of object that an object reference points to |
+| [H5Rget_type](/documentation/hdf5/latest/group___h5_r.html#ga56989d33835ec289269d366dc28aa4ad) | N | Retrieves the type of reference |
+| [H5Ropen_attr](/documentation/hdf5/latest/group___h5_r.html#ga2a00d73b9a13b9069d0ad39225dd9f71) | N | Opens the referenced HDF5 attribute |
+| [H5Ropen_object](/documentation/hdf5/latest/group___h5_r.html#gaa6692bd3a5b490c8db05b90a5888d0dd) | N | Opens the referenced HDF5 object |
+| [H5Ropen_region](/documentation/hdf5/latest/group___h5_r.html#ga400154b014acd1736bae9a127f4e9a1a) | N | Sets up a dataspace and selection as specified by a region reference |
 |  | | |
-| [H5Scombine_hyperslab](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#gae7578a93bb7b22989bcb737f26b60ad1) | N | Performs an operation on a hyperslab and an existing selection and returns the resulting selection |
-| [H5Scombine_select](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga356600d12d3cf0db53cc27b212d75b08) | N | Combines two hyperslab selections with an operation, returning a dataspace with the resulting selection | 
-| [H5Sencode](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga35e289baf490229e233296929fbf5208)
- [H5Sencode1](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga82cf9f6af03ad89be21c36922e03baea)
- [H5Sencode2](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga178ec7b8769ad5704a170d9bd3421074) | N/A | Encodes a dataspace object description into a binary buffer<br>The function H5S_ENCODE was renamed to H5S_ENCODE1 and deprecated in this release. The macro H5S_ENCODE and the function H5S_ENCODE2 were introduced in this release. |
-| [H5Smodify_select](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga0ccb190f72fe41a927407ffb9f19ef1b) | N | Refines a hyperslab selection with an operation using a second hyperslab to modify it |
-| [H5Ssel_iter_close](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga75b79e15e8fa3e591f7ab25a8624e690) | N | Closes a dataspace selection iterator |
-| [H5Ssel_iter_create](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#gac73247e4ef206a47c8aa97dd2ff5febe) | N | Creates a dataspace selection iterator for a dataspace's selection |
-| [H5Ssel_iter_get_seq_list](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga793fb6ff150f45d43e379995b5c0d297) | N | Retrieves a list of offset / length sequences for the elements in an iterator |
-| [H5Sselect_adjust](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga64f08c187b899f2728d4ac016d44f890) | N |  Adjusts a selection by subtracting an offset |
-| [H5Sselect_copy](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga57e5eba2d1b282803835ba3f7e0b9bfa) | N | Copies a selection from one dataspace to another |
-| [H5Sselect_intersect_block](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga51472bcb9af024675fba6294a6aefa5e) | N | Checks if current selection intersects with a block |
-| [H5Sselect_project_intersection](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#ga1e914ba45afb15ded99a0afeaf124c04) | N | Projects the intersection of two source selections to a destination selection |
-| [H5Sselect_shape_same](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_s.html#gafc6cafae877900ee060709eaa0b9b261) | N | Checks if two selections are the same shape |
+| [H5Scombine_hyperslab](/documentation/hdf5/latest/group___h5_s.html#gae7578a93bb7b22989bcb737f26b60ad1) | N | Performs an operation on a hyperslab and an existing selection and returns the resulting selection |
+| [H5Scombine_select](/documentation/hdf5/latest/group___h5_s.html#ga356600d12d3cf0db53cc27b212d75b08) | N | Combines two hyperslab selections with an operation, returning a dataspace with the resulting selection | 
+| [H5Sencode](/documentation/hdf5/latest/group___h5_s.html#ga35e289baf490229e233296929fbf5208)
+ [H5Sencode1](/documentation/hdf5/latest/group___h5_s.html#ga82cf9f6af03ad89be21c36922e03baea)
+ [H5Sencode2](/documentation/hdf5/latest/group___h5_s.html#ga178ec7b8769ad5704a170d9bd3421074) | N/A | Encodes a dataspace object description into a binary buffer<br>The function H5S_ENCODE was renamed to H5S_ENCODE1 and deprecated in this release. The macro H5S_ENCODE and the function H5S_ENCODE2 were introduced in this release. |
+| [H5Smodify_select](/documentation/hdf5/latest/group___h5_s.html#ga0ccb190f72fe41a927407ffb9f19ef1b) | N | Refines a hyperslab selection with an operation using a second hyperslab to modify it |
+| [H5Ssel_iter_close](/documentation/hdf5/latest/group___h5_s.html#ga75b79e15e8fa3e591f7ab25a8624e690) | N | Closes a dataspace selection iterator |
+| [H5Ssel_iter_create](/documentation/hdf5/latest/group___h5_s.html#gac73247e4ef206a47c8aa97dd2ff5febe) | N | Creates a dataspace selection iterator for a dataspace's selection |
+| [H5Ssel_iter_get_seq_list](/documentation/hdf5/latest/group___h5_s.html#ga793fb6ff150f45d43e379995b5c0d297) | N | Retrieves a list of offset / length sequences for the elements in an iterator |
+| [H5Sselect_adjust](/documentation/hdf5/latest/group___h5_s.html#ga64f08c187b899f2728d4ac016d44f890) | N |  Adjusts a selection by subtracting an offset |
+| [H5Sselect_copy](/documentation/hdf5/latest/group___h5_s.html#ga57e5eba2d1b282803835ba3f7e0b9bfa) | N | Copies a selection from one dataspace to another |
+| [H5Sselect_intersect_block](/documentation/hdf5/latest/group___h5_s.html#ga51472bcb9af024675fba6294a6aefa5e) | N | Checks if current selection intersects with a block |
+| [H5Sselect_project_intersection](/documentation/hdf5/latest/group___h5_s.html#ga1e914ba45afb15ded99a0afeaf124c04) | N | Projects the intersection of two source selections to a destination selection |
+| [H5Sselect_shape_same](/documentation/hdf5/latest/group___h5_s.html#gafc6cafae877900ee060709eaa0b9b261) | N | Checks if two selections are the same shape |
 |  |
-| [H5Treclaim](https://support.hdfgroup.org/documentation/hdf5/latest/group___v_l_e_n.html#ga6851783a68a0f868c27300cb5622fbbe) | N | Frees the buffers allocated for storing variable-length data in memory |
+| [H5Treclaim](/documentation/hdf5/latest/group___v_l_e_n.html#ga6851783a68a0f868c27300cb5622fbbe) | N | Frees the buffers allocated for storing variable-length data in memory |
 | | | |
-| [H5VLclose](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gaa3324ac7aedf9362b498226903288094) | Y | Closes a VOL connector identifier |
-| [H5VLget_connector_id(](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga5b69c29931e55208517c598ac3039f77) | Y | Retrieves the VOL connector identifier for a given object identifier |
-| [H5VLget_connector_id_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gabcbf9b9b07a6b60e17ff9681684f944d) | Y | Retrieves the identifier for a registered VOL connector name |
-| [H5VLget_connector_id_by_value](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga8f6d366bc6b8323bbffe1e5a5ba18bee) | Y | Retrieves the identifier for a registered VOL connector value |
-| [H5VLget_connector_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gaf326406d7733c0ab8d12118c13c78dfa) | Y | Retrieves the connector name for the VOL associated with the object or file identifier |
-| [H5VLis_connector_registered_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga9be3c92e4430b9cf42a376534a47fcca) | Y | Tests whether a VOL class has been registered or not for a connector name |
-| [H5VLis_connector_registered_by_value](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga83ba8986ed68f67c41b492dfd273804b) | Y | Tests whether a VOL class has been registered or not for a connector value |
-| [H5VLregister_connector](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l_d_e_v.html#ga439c150299522a0e0f401a86d083097b) | N | Registers a new VOL connector |
-| [H5VLregister_connector_by_name](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gaf48d1225927e1e701656346b832ee6b1) | Y | Registers a new VOL connector by name |
-| [H5VLregister_connector_by_value](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#ga11e69930e47f654805a265f417412ea8) | Y | Registers a new VOL connector by connector value |
-| [H5VLunregister_connector](https://support.hdfgroup.org/documentation/hdf5/latest/group___h5_v_l.html#gaffbdc22f724c2c818f3be3845145d73e) | Y | Removes a VOL connector identifier from the library |
+| [H5VLclose](/documentation/hdf5/latest/group___h5_v_l.html#gaa3324ac7aedf9362b498226903288094) | Y | Closes a VOL connector identifier |
+| [H5VLget_connector_id(](/documentation/hdf5/latest/group___h5_v_l.html#ga5b69c29931e55208517c598ac3039f77) | Y | Retrieves the VOL connector identifier for a given object identifier |
+| [H5VLget_connector_id_by_name](/documentation/hdf5/latest/group___h5_v_l.html#gabcbf9b9b07a6b60e17ff9681684f944d) | Y | Retrieves the identifier for a registered VOL connector name |
+| [H5VLget_connector_id_by_value](/documentation/hdf5/latest/group___h5_v_l.html#ga8f6d366bc6b8323bbffe1e5a5ba18bee) | Y | Retrieves the identifier for a registered VOL connector value |
+| [H5VLget_connector_name](/documentation/hdf5/latest/group___h5_v_l.html#gaf326406d7733c0ab8d12118c13c78dfa) | Y | Retrieves the connector name for the VOL associated with the object or file identifier |
+| [H5VLis_connector_registered_by_name](/documentation/hdf5/latest/group___h5_v_l.html#ga9be3c92e4430b9cf42a376534a47fcca) | Y | Tests whether a VOL class has been registered or not for a connector name |
+| [H5VLis_connector_registered_by_value](/documentation/hdf5/latest/group___h5_v_l.html#ga83ba8986ed68f67c41b492dfd273804b) | Y | Tests whether a VOL class has been registered or not for a connector value |
+| [H5VLregister_connector](/documentation/hdf5/latest/group___h5_v_l_d_e_v.html#ga439c150299522a0e0f401a86d083097b) | N | Registers a new VOL connector |
+| [H5VLregister_connector_by_name](/documentation/hdf5/latest/group___h5_v_l.html#gaf48d1225927e1e701656346b832ee6b1) | Y | Registers a new VOL connector by name |
+| [H5VLregister_connector_by_value](/documentation/hdf5/latest/group___h5_v_l.html#ga11e69930e47f654805a265f417412ea8) | Y | Registers a new VOL connector by connector value |
+| [H5VLunregister_connector](/documentation/hdf5/latest/group___h5_v_l.html#gaffbdc22f724c2c818f3be3845145d73e) | Y | Removes a VOL connector identifier from the library |
  
 
 ### In the C++ Wrapper
@@ -195,8 +195,8 @@ Following are the new or changed APIs introduced in HDF5-1.12.0. Those introduce
 
 
 ## API Compatibility
-See API Compatibility Macros in HDF5 for details on using HDF5 version 1.12 with previous releases.
+See [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 for details on using HDF5 version 1.12 with previous releases.
 
-[Compatibility report for Release 1.12.0 versus Release 1.10.6](Compatibility report for Release 1.12.0 versus Release 1.10.6)
+[Compatibility report for Release 1.12.0 versus Release 1.10.6](https://htmlpreview.github.io/?https://github.com/hdfgroup/hdf5doc/8f09cef4b2b62d56d6956ff5ddb689ab642fc763/html/ADGuide/Compatibility_Report/hdf5-1.12-0-vs-hdf5-1.10.6-interface_compatibility_report.html)
 
  

--- a/documentation/hdf5-docs/release_specifics/sw_changes_1.14.md
+++ b/documentation/hdf5-docs/release_specifics/sw_changes_1.14.md
@@ -11,9 +11,9 @@ redirect_from:
 See [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 for details on using HDF5 version 1.14 with previous releases.
 
 
-* [Compatibility report for Release 1.14.6 versus Release 1.14.5](/releases/hdf5/v1_14/v1_14_6/downloads/compat_report/index.html)
-* [Compatibility report for Release 1.14.5 versus Release 1.14.4](/releases/hdf5/v1_14/v1_14_5/downloads/compat_report/index.html)
-* [Compatibility report for Release 1.14.4 versus Release 1.14.3](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.4.2/hdf5-1.14.4-2.html.abi.reports.tar.gz)
+* [Compatibility report for Release 1.14.6 versus Release 1.14.5](/releases/hdf5/v1_14/v1_14_6/downloads/compat_report/index.html) [GZ file](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.html.abi.reports.tar.gz)
+* [Compatibility report for Release 1.14.5 versus Release 1.14.4](/releases/hdf5/v1_14/v1_14_5/downloads/compat_report/index.html) [GZ file](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.5/hdf5-1.14.5.html.abi.reports.tar.gz)
+* Compatibility report for Release 1.14.4 versus Release 1.14.3 [GZ file](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.4.2/hdf5-1.14.4-2.html.abi.reports.tar.gz)
 * [Compatibility report for Release 1.14.3 versus Release 1.14.2](https://htmlpreview.github.io/?https://raw.githubusercontent.com/HDFGroup/hdf5doc/master/html/ADGuide/Compatibility_Report/hdf5-1.14.2-vs-hdf5-1.14.3-interface_compatibility_report.html)
 * [Compatibility report for Release 1.14.2 versus Release 1.14.1](https://htmlpreview.github.io/?https://raw.githubusercontent.com/HDFGroup/hdf5doc/master/html/ADGuide/Compatibility_Report/hdf5-1.14.1-2-vs-hdf5-1.14.2-interface_compatibility_report.html)
 * [Compatibility report for Release 1.14.1 versus Release 1.14.0](https://htmlpreview.github.io/?https://raw.githubusercontent.com/HDFGroup/hdf5doc/master/html/ADGuide/Compatibility_Report/hdf5-1.14.0-vs-hdf5-1.14.1-interface_compatibility_report.html)
@@ -43,7 +43,7 @@ The release notes also list changes made to the library, but these notes tend to
 
 ### New and Changed Functions, Classes, Subroutines, Wrappers, and Macros
 
-* [Compatibility report for Release 1.14.6 versus Release 1.14.5](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.html.abi.reports.tar.gz)
+* [Compatibility report for Release 1.14.6 versus Release 1.14.5](/releases/hdf5/v1_14/v1_14_6/downloads/compat_report/index.html)
 
 <h2 id="5versus4">Release 1.14.5 versus Release 1.14.4</h2>
 
@@ -58,7 +58,7 @@ Following are the new APIs/macros introduced in HDF5-1.14.5.
 | [H5Epause_stack](/documentation/hdf5/latest/group___h5_e.html#ga4c0064d86c4ce9b0ddef832dcc4158ed) | Pause pushing errors on an error stack |
 | [H5Eresume_stack](/documentation/hdf5/latest/group___h5_e.html#gaab20d99bd5f79d4e3c1996ddc22c3fa8) | Resume pushing errors on an error stack |
 
-* [Compatibility report for Release 1.14.5 versus Release 1.14.4](https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.5/hdf5-1.14.5.html.abi.reports.tar.gz)
+* [Compatibility report for Release 1.14.5 versus Release 1.14.4](/releases/hdf5/v1_14/v1_14_5/downloads/compat_report/index.html)
 
 <h2 id="4versus3">Release 1.14.4 versus Release 1.14.3</h2>
 
@@ -176,7 +176,7 @@ HDF5 version 1.14.0 introduces the following new features:
 
 Users might find these names familiar already and that is because they were introduced in the experimental series 1.13.
 
-In addition, this version provides many new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.12.2 to Release 1.14.0.  HDF5 1.14.0 adds no new API calls that require use of the API Compatibility Macros for the main library.  Some calls have been removed or have had their signature change, however.
+In addition, this version provides many new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.12.2 to Release 1.14.0.  HDF5 1.14.0 adds no new API calls that require use of the [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) for the main library.  Some calls have been removed or have had their signature change, however.
 
 New and Changed Functions, Classes, Subroutines, Wrappers, and Macros
 In the C Interface (main library)

--- a/documentation/hdf5-docs/release_specifics/sw_changes_1.8.md
+++ b/documentation/hdf5-docs/release_specifics/sw_changes_1.8.md
@@ -3497,7 +3497,7 @@ ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t size)
 
 H5DSget_scale_name    
 
-hssize_t H5DSget_scale_name(hid_t did, char name, size_t *size)
+hssize_t H5DSget_scale_name(hid_t did, char name, size_t \*size)
 
 H5DSget_num_scales
 
@@ -3545,7 +3545,7 @@ H5Pget_fapl_stream
 
       
 
-The stream virtual file driver (H5FD_STREAM) has been removed from the HDF5 distribution. The functionality was last available from http://hdf5-addons.origo.ethz.ch/.
+The stream virtual file driver (H5FD_STREAM) has been removed from the HDF5 distribution. The functionality was last available from http://hdf5-addons.origo.ethz.ch/.  Update: as of 2025, this URL is no longer valid.
 
 H5Tset_overflow
 H5Tget_overflow
@@ -3554,7 +3554,7 @@ H5Tget_overflow
 
 These two functions are replaced by H5Pget_type_conv_cb and H5Pset_type_conv_cb.
 
-Several functions, subroutines, and wrappers are deprecated in this HDF5 release and may eventually be removed from the HDF5 distribution and from the HDF5 Reference Manual. A Release 1.6.x compatibility mode is provided enabling these and other Release 1.6.x compatibility features, but is available only if the HDF5 Library is configured with the default settings or with the flag --with-default-api-version=v16. Release 1.8.0 also provides macros that can be mapped selectively to 1.6.x and 1.8.0 function versions according to the needs of a user application. The backward compatibility mode is enabled in the Release 1.8.0 binaries distributed by NCSA. See API Compatibility Macros in HDF5 for full details.
+Several functions, subroutines, and wrappers are deprecated in this HDF5 release and may eventually be removed from the HDF5 distribution and from the HDF5 Reference Manual. A Release 1.6.x compatibility mode is provided enabling these and other Release 1.6.x compatibility features, but is available only if the HDF5 Library is configured with the default settings or with the flag --with-default-api-version=v16. Release 1.8.0 also provides macros that can be mapped selectively to 1.6.x and 1.8.0 function versions according to the needs of a user application. The backward compatibility mode is enabled in the Release 1.8.0 binaries distributed by NCSA. See [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 for full details.
 
  
 Deprecated functions are marked in the function index at the beginning of each API section in the HDF5 Reference Manual.
@@ -3620,7 +3620,7 @@ Two new filter identifiers are available for the filter or filter_id parameters:
  
 
 Functions with Changed Syntax
-Function syntax changes in this release are handled through the mechanism described in API Compatibility Macros in HDF5.
+Function syntax changes in this release are handled through the mechanism described in [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5.
 
 Exceptions:
 
@@ -3647,7 +3647,7 @@ The new function signature is generally considered equivalent to the old signatu
 (This note added in February 2010, following Release 1.8.4.)
 
 Renamed Functions
-The following C functions have been renamed. The original function names remain available under certain circumstances; see API Compatibility Macros in HDF5 for full details.
+The following C functions have been renamed. The original function names remain available under certain circumstances; see [API Compatibility Macros](/documentation/hdf5/latest/api-compat-macros.html) in HDF5 for full details.
 
 Original name
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -7,12 +7,12 @@ redirect_from:
 # HDF Software Documentation
 
 ## HDF5 Library, Tools, and Extensions
-* [Documentation (latest)](https://support.hdfgroup.org/documentation/hdf5/latest/) - User Guide, Reference Manual, and other documentation
+* [Documentation (latest)](/documentation/hdf5/latest/) - User Guide, Reference Manual, and other documentation
 * [Release Specific Information](/documentation/hdf5-docs/release_specific_info.html) - Information specific to each release series
 * [HDF5 Application Topics](/documentation/hdf5-docs/hdf5_topics_list.html) - General and advanced topics in HDF5 for application developers
 * [Registered Filter Plugins](https://github.com/HDFGroup/hdf5_plugins/blob/master/docs/RegisteredFilterPlugins.md) - List of registered filter plugins
-* [Registered Virtual File Drivers (VFDs)](https://support.hdfgroup.org/releases/hdf5/documentation/registered_virtual_file_drivers_vfds.html) - List of registered VFDs
-* [Registered Virtual Object Layer (VOL) Connectors](https://support.hdfgroup.org/releases/hdf5/documentation/registered_vol_connectors.html) - List of registered VOL connectors
+* [Registered Virtual File Drivers (VFDs)](/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html) - List of registered VFDs
+* [Registered Virtual Object Layer (VOL) Connectors](/documentation/hdf5-docs/registered_vol_connectors.html) - List of registered VOL connectors
 
 ## HDFView 
 
@@ -25,23 +25,23 @@ redirect_from:
 
 ## Highly Scalable Data Service (HSDS)
 * [Overview of HSDS](https://www.hdfgroup.org/solutions/highly-scalable-data-service-hsds/) 
-* [Authorization and Authentication](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/authorization.md)
-* [Azure Active Directory](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/azure_ad_setup.md)
-* [Docker setup instructions](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/setup_docker.md)
+* [Authorization and Authentication](https://github.com/HDFGroup/hsds/blob/master/docs/authorization.md)
+* [Azure Active Directory](https://github.com/HDFGroup/hsds/blob/master/docs/azure_ad_setup.md)
+* [Docker setup instructions](https://github.com/HDFGroup/hsds/blob/master/docs/setup_docker.md)
 * [HDF Rest API](https://github.com/HDFGroup/hdf-rest-api/blob/master/README.md) 
-* [HSDS for AWS Lambda](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/aws_lambda_setup.md)
-* [Installation with Kubernetes on AWS](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/kubernetes_install_azure.md)
-* [Installation with Azure Kubernetes](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/kubernetes_install_azure.md)
-* [Keycloak Authentication](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/keycloak_setup.md)
-* [Post Install Configuration](https://raw.githubusercontent.com/HDFGroup/hsds/master/docs/post_install.md)
+* [HSDS for AWS Lambda](https://github.com/HDFGroup/hsds/blob/master/docs/aws_lambda_setup.md)
+* [Installation with Kubernetes on AWS](https://github.com/HDFGroup/hsds/blob/master/docs/kubernetes_install_azure.md)
+* [Installation with Azure Kubernetes](https://github.com/HDFGroup/hsds/blob/master/docs/kubernetes_install_azure.md)
+* [Keycloak Authentication](https://github.com/HDFGroup/hsds/blob/master/docs/keycloak_setup.md)
+* [Post Install Configuration](https://github.com/HDFGroup/hsds/blob/master/docs/post_install.md)
 
 ## HDF4 Library and Tools
 * [Reference Manual](https://zenodo.org/records/13310709)
 * [User Guide](https://zenodo.org/records/13310689)
 * [HDF4 Specification and Developers Guide](https://zenodo.org/records/13310722) 
-* [Build and Install HDF4 Applications with CMake](https://raw.githubusercontent.com/HDFGroup/hdf4/master/release_notes/USING_HDF4_CMake.txt)
-* [Build and Install HDF4 C, C++, Fortran Libraries and tools with CMake](https://raw.githubusercontent.com/HDFGroup/hdf4/master/release_notes/INSTALL_CMake.txt)
-* [HDF 4.2 to 4.3 Migration Guide](https://raw.githubusercontent.com/HDFGroup/hdf4/master/doc/HDF-4.2-to-4.3-migration.md) 
+* [Build and Install HDF4 Applications with CMake](https://github.com/HDFGroup/hdf4/blob/master/release_notes/USING_HDF4_CMake.txt)
+* [Build and Install HDF4 C, C++, Fortran Libraries and tools with CMake](https://github.com/HDFGroup/hdf4/blob/master/release_notes/INSTALL_CMake.txt)
+* [HDF 4.2 to 4.3 Migration Guide](https://github.com/HDFGroup/hdf4/blob/master/doc/HDF-4.2-to-4.3-migration.md) 
 
 ## h4h5Tools
 * [Mapping HDF4 Objects to HDF5 Objects](https://zenodo.org/records/13310794) 


### PR DESCRIPTION
Used
    /documentation/hdf5/latest
    /documentation/advanced_topics
    /documentation/hdf5_topics
    /documentation/release_specifics
Added missing link for API Compatibility Macros